### PR TITLE
v4 (PR-B): .rapg.toml + rapg hook for project-scoped secrets

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -38,19 +38,24 @@ jobs:
         with:
           go-version: '1.25'
 
-      - name: Install sqlite headers
-        run: sudo apt-get update && sudo apt-get install -y libsqlite3-dev
+      - name: Install sqlite + vhs runtime deps
+        # vhs needs ttyd + ffmpeg. ubuntu-latest ships modern enough versions
+        # in apt; we install them explicitly rather than relying on
+        # vhs-action's internal installer (which has been flaky for ffmpeg).
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libsqlite3-dev ffmpeg ttyd
+
+      - name: Install vhs
+        run: go install github.com/charmbracelet/vhs@latest
 
       - name: Build rapg
         # Build the whole package, not just main.go — cmd/rapg now spans
         # multiple files (main.go, hooks.go, ...).
         run: go build -o rapg ./cmd/rapg
 
-      - name: Validate tape
-        uses: charmbracelet/vhs-action@v2
-        with:
-          path: 'demo.tape'
-          install-fonts: true
+      - name: Render demo
+        run: vhs demo.tape
 
       - name: Upload demo as artifact (PR only)
         if: github.event_name == 'pull_request'

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -42,7 +42,9 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libsqlite3-dev
 
       - name: Build rapg
-        run: go build -o rapg cmd/rapg/main.go
+        # Build the whole package, not just main.go — cmd/rapg now spans
+        # multiple files (main.go, hooks.go, ...).
+        run: go build -o rapg ./cmd/rapg
 
       - name: Validate tape
         uses: charmbracelet/vhs-action@v2

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,7 +16,7 @@ builds:
     goarch:
       - amd64
       - arm64
-    main: ./cmd/rapg/main.go
+    main: ./cmd/rapg
     ldflags:
       - -s -w
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build run test clean fmt vet install demo
 
 BINARY_NAME=rapg
-MAIN_PATH=cmd/rapg/main.go
+MAIN_PATH=./cmd/rapg
 
 # Build the binary
 build:

--- a/README.md
+++ b/README.md
@@ -71,9 +71,18 @@ Drop a `.rapg.toml` at your repository root to scope which secrets `rapg run` an
 ```toml
 namespace = "myapp"
 
-# Optional: explicit env-key whitelist. If omitted, every secret in
-# the namespace whose Env Key is non-empty is injected.
+# Optional. Three states:
+#   - omitted               → no whitelist, inject every env-tagged
+#                             secret in the namespace
+#   - keys = []             → explicit deny-all (project recognized,
+#                             but no env vars injected)
+#   - keys = ["A", "B"]     → standard whitelist
 keys = ["DATABASE_URL", "ANTHROPIC_API_KEY"]
+
+# Optional. Default false. When true, entries with empty Namespace
+# (the 'global' bucket) are also injected. Project entries override
+# global on env-key collision.
+# inherit_global = true
 ```
 
 When you add a secret in the TUI, fill in the `Namespace` field with the same value (e.g., `myapp`). Then:
@@ -89,7 +98,7 @@ Resolution rules:
 
 - Discovery walks up from `cwd` to `/`. The first `.rapg.toml` wins.
 - No `.rapg.toml` found → only entries with empty Namespace ("global") are injected.
-- A namespaced entry is invisible outside its project, even on a global run.
+- A namespaced entry is invisible outside its project unless the project opts in via `inherit_global = true` — which lets shared utility secrets (e.g. `GITHUB_TOKEN`) live once in the global bucket and be borrowed by projects that ask for them. Project entries always win on key collision.
 - Same `Service` / `Username` pair can exist across multiple namespaces.
 
 ## Shell hook (informational)

--- a/README.md
+++ b/README.md
@@ -57,31 +57,83 @@ rapg run -- python examples/main.py
 | Key | Action |
 | --- | --- |
 | `j` / `k` / arrows | Navigate the entry list |
-| `n` | New entry |
+| `n` | New entry (Service, Username, Password, TOTP, Namespace, Env Key, Notes) |
 | `enter` / `space` | Open detail view |
 | `enter` (in detail) | Copy password to clipboard |
 | `ctrl+t` | Copy current TOTP code |
 | `d` | Delete the selected entry |
 | `q` | Quit |
 
+## Project-scoped secrets (`.rapg.toml`)
+
+Drop a `.rapg.toml` at your repository root to scope which secrets `rapg run` and `rapg export` see:
+
+```toml
+namespace = "myapp"
+
+# Optional: explicit env-key whitelist. If omitted, every secret in
+# the namespace whose Env Key is non-empty is injected.
+keys = ["DATABASE_URL", "ANTHROPIC_API_KEY"]
+```
+
+When you add a secret in the TUI, fill in the `Namespace` field with the same value (e.g., `myapp`). Then:
+
+```bash
+cd ~/code/myapp
+rapg run -- claude code
+# [rapg] project: myapp (/Users/me/code/myapp/.rapg.toml)
+# child sees only myapp's DATABASE_URL and ANTHROPIC_API_KEY
+```
+
+Resolution rules:
+
+- Discovery walks up from `cwd` to `/`. The first `.rapg.toml` wins.
+- No `.rapg.toml` found → only entries with empty Namespace ("global") are injected.
+- A namespaced entry is invisible outside its project, even on a global run.
+- Same `Service` / `Username` pair can exist across multiple namespaces.
+
+## Shell hook (informational)
+
+`rapg hook <shell>` prints a snippet that announces project entry/exit on `cd`. It does **not** auto-inject secrets — run `rapg run -- <cmd>` for that. Auto-injection (direnv-style) is planned for v4.1; doing it safely without an in-shell key cache is a separate problem.
+
+```bash
+# zsh: ~/.zshrc
+eval "$(rapg hook zsh)"
+
+# bash: ~/.bashrc
+eval "$(rapg hook bash)"
+
+# fish: ~/.config/fish/config.fish
+rapg hook fish | source
+```
+
+After installing, `cd` between project directories prints:
+
+```text
+[rapg] entered project: myapp  (rapg run -- <cmd> to inject)
+[rapg] left project: myapp
+```
+
 ## Subcommands
 
 | Command | Purpose |
 | --- | --- |
 | `rapg` | Launch the TUI |
-| `rapg run -- <cmd>` | Inject secrets into a child process |
+| `rapg run -- <cmd>` | Inject secrets into a child process (respects `.rapg.toml`) |
 | `rapg gen [length]` | Generate a cryptographically random password |
-| `rapg export` | Print env-tagged secrets as `KEY=value` lines (use sparingly: Docker, CI debugging) |
+| `rapg export` | Print env-tagged secrets as `KEY=value` lines (respects `.rapg.toml`) |
+| `rapg project` | Print the current project's namespace; exit 1 if not in a project |
+| `rapg hook <shell>` | Print a `cd` notifier snippet for `zsh` / `bash` / `fish` |
 | `rapg nuke` | Wipe the local vault after confirmation |
 
 ## Roadmap
 
-The next milestones lean into the agent-leakage problem:
+Next on the agent-leakage track:
 
-1. `.rapg.toml` per-project config and a shell hook so `cd project/` auto-loads the right secrets.
-2. `rapg redact <file>` — scan a file for vault values and mask them; use this on agent transcripts before sharing.
-3. `rapg session log` — audit which command saw which secret and when.
-4. `rapg proxy --provider anthropic|openai` (experimental) — local HTTP proxy that holds the real API key, so agents only ever see a short-lived proxy token.
+1. `rapg redact <file>` — scan a file for vault values and mask them; use this on agent transcripts before sharing.
+2. `rapg session log` — audit which command saw which secret and when.
+3. `rapg proxy --provider anthropic|openai` (experimental) — local HTTP proxy that holds the real API key, so agents only ever see a short-lived proxy token.
+4. Direnv-style auto-injection on `cd`, with a TPM / Touch ID / Secure Enclave-backed key cache.
 
 ## Security
 

--- a/cmd/rapg/hooks.go
+++ b/cmd/rapg/hooks.go
@@ -1,0 +1,66 @@
+package main
+
+// hookSnippets maps a shell name to the snippet `rapg hook <shell>` prints.
+//
+// Each snippet defines an in-shell function that calls `rapg project` to
+// detect the nearest .rapg.toml namespace and emits a one-line notice when
+// the namespace changes between cwds. RAPG_PROJECT carries the previous
+// state across invocations.
+//
+// These hooks are deliberately informational only. They do not unlock the
+// vault, decrypt secrets, or modify the environment. To actually inject
+// secrets, run `rapg run -- <cmd>` (which reads the same .rapg.toml).
+var hookSnippets = map[string]string{
+	"zsh": `# rapg shell hook (zsh)
+# Install: eval "$(rapg hook zsh)"
+_rapg_chpwd() {
+  local current=""
+  current="$(rapg project 2>/dev/null)" || current=""
+  if [[ "$current" != "${RAPG_PROJECT:-}" ]]; then
+    if [[ -n "$current" ]]; then
+      print -P "%F{cyan}[rapg]%f entered project: $current  (rapg run -- <cmd> to inject)"
+    elif [[ -n "${RAPG_PROJECT:-}" ]]; then
+      print -P "%F{cyan}[rapg]%f left project: $RAPG_PROJECT"
+    fi
+    export RAPG_PROJECT="$current"
+  fi
+}
+typeset -ga chpwd_functions
+chpwd_functions+=(_rapg_chpwd)
+_rapg_chpwd
+`,
+	"bash": `# rapg shell hook (bash)
+# Install: eval "$(rapg hook bash)"
+_rapg_check() {
+  local current=""
+  current="$(rapg project 2>/dev/null)" || current=""
+  if [[ "$current" != "${RAPG_PROJECT:-}" ]]; then
+    if [[ -n "$current" ]]; then
+      printf '\033[36m[rapg]\033[0m entered project: %s  (rapg run -- <cmd> to inject)\n' "$current"
+    elif [[ -n "${RAPG_PROJECT:-}" ]]; then
+      printf '\033[36m[rapg]\033[0m left project: %s\n' "$RAPG_PROJECT"
+    fi
+    export RAPG_PROJECT="$current"
+  fi
+}
+case ";${PROMPT_COMMAND:-};" in
+  *";_rapg_check;"*) ;;
+  *) PROMPT_COMMAND="_rapg_check;${PROMPT_COMMAND:-}" ;;
+esac
+`,
+	"fish": `# rapg shell hook (fish)
+# Install: rapg hook fish | source
+function __rapg_check --on-variable PWD --description "rapg project notifier"
+  set -l current (rapg project 2>/dev/null; or echo "")
+  if test "$current" != "$RAPG_PROJECT"
+    if test -n "$current"
+      printf '\033[36m[rapg]\033[0m entered project: %s  (rapg run -- <cmd> to inject)\n' "$current"
+    else if test -n "$RAPG_PROJECT"
+      printf '\033[36m[rapg]\033[0m left project: %s\n' "$RAPG_PROJECT"
+    end
+    set -gx RAPG_PROJECT "$current"
+  end
+end
+__rapg_check
+`,
+}

--- a/cmd/rapg/main.go
+++ b/cmd/rapg/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/awnumar/memguard"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/kanywst/rapg/internal/config"
 	"github.com/kanywst/rapg/internal/core"
 	"github.com/kanywst/rapg/internal/storage"
 	"github.com/kanywst/rapg/internal/ui"
@@ -107,9 +109,10 @@ func main() {
 		Use:   "export",
 		Short: "Export secrets with EnvKey set to .env format",
 		Run: func(cmd *cobra.Command, args []string) {
+			project := loadProject()
 			unlockVault()
 
-			envVars, err := core.GetEnvVars()
+			envVars, err := core.GetEnvVars(project)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error getting env vars: %v\n", err)
 				os.Exit(1)
@@ -134,9 +137,10 @@ func main() {
 Note: Secrets configured in Rapg will override any existing environment variables with the same name.`,
 		Args: cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			project := loadProject()
 			unlockVault()
 
-			envVars, err := core.GetEnvVars()
+			envVars, err := core.GetEnvVars(project)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error getting env vars: %v\n", err)
 				os.Exit(1)
@@ -212,4 +216,25 @@ func unlockVault() {
 		fmt.Fprintln(os.Stderr, "Invalid password.")
 		os.Exit(1)
 	}
+}
+
+// loadProject resolves the nearest .rapg.toml from the current working
+// directory. Returns nil if none was found (legacy behavior: secrets in the
+// global namespace are injected). On parse failure, returns nil and warns
+// rather than aborting — a malformed config should not lock the user out.
+func loadProject() *config.Project {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil
+	}
+	p, path, err := config.Find(cwd)
+	if errors.Is(err, config.ErrNotFound) {
+		return nil
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[rapg] warning: ignoring %s: %v\n", path, err)
+		return nil
+	}
+	fmt.Fprintf(os.Stderr, "[rapg] project: %s (%s)\n", p.Namespace, path)
+	return p
 }

--- a/cmd/rapg/main.go
+++ b/cmd/rapg/main.go
@@ -204,8 +204,8 @@ Designed for shell hooks — use 'rapg hook <shell>' to install one.`,
 	}
 
 	hookCmd := &cobra.Command{
-		Use:       "hook <shell>",
-		Short:     "Print a shell hook that announces .rapg.toml projects on cd",
+		Use:   "hook <shell>",
+		Short: "Print a shell hook that announces .rapg.toml projects on cd",
 		Long: `Print a shell snippet that, when sourced, prints '[rapg] entered project: X'
 when you 'cd' into a directory whose .rapg.toml declares a namespace, and
 '[rapg] left project: X' when you leave it. Purely informational — does

--- a/cmd/rapg/main.go
+++ b/cmd/rapg/main.go
@@ -183,7 +183,57 @@ Note: Secrets configured in Rapg will override any existing environment variable
 		},
 	}
 
-	rootCmd.AddCommand(genCmd, nukeCmd, exportCmd, runCmd)
+	projectCmd := &cobra.Command{
+		Use:   "project",
+		Short: "Print the current project's namespace (exit 1 if not in a project)",
+		Long: `Walk up from the current directory looking for .rapg.toml. If found,
+print the namespace to stdout and exit 0. Otherwise, print nothing and exit 1.
+
+Designed for shell hooks — use 'rapg hook <shell>' to install one.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			cwd, err := os.Getwd()
+			if err != nil {
+				os.Exit(1)
+			}
+			p, _, err := config.Find(cwd)
+			if err != nil {
+				os.Exit(1)
+			}
+			fmt.Println(p.Namespace)
+		},
+	}
+
+	hookCmd := &cobra.Command{
+		Use:       "hook <shell>",
+		Short:     "Print a shell hook that announces .rapg.toml projects on cd",
+		Long: `Print a shell snippet that, when sourced, prints '[rapg] entered project: X'
+when you 'cd' into a directory whose .rapg.toml declares a namespace, and
+'[rapg] left project: X' when you leave it. Purely informational — does
+not auto-inject secrets. Run 'rapg run -- <cmd>' to actually inject.
+
+Install with:
+
+  # zsh (~/.zshrc)
+  eval "$(rapg hook zsh)"
+
+  # bash (~/.bashrc)
+  eval "$(rapg hook bash)"
+
+  # fish (~/.config/fish/config.fish)
+  rapg hook fish | source`,
+		ValidArgs: []string{"zsh", "bash", "fish"},
+		Args:      cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+		Run: func(cmd *cobra.Command, args []string) {
+			snippet, ok := hookSnippets[args[0]]
+			if !ok {
+				fmt.Fprintf(os.Stderr, "Unsupported shell: %s (zsh|bash|fish)\n", args[0])
+				os.Exit(1)
+			}
+			fmt.Print(snippet)
+		},
+	}
+
+	rootCmd.AddCommand(genCmd, nukeCmd, exportCmd, runCmd, projectCmd, hookCmd)
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 )
 
 require (
+	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/awnumar/memcall v0.4.0 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/boombuler/barcode v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/awnumar/memcall v0.4.0 h1:B7hgZYdfH6Ot1Goaz8jGne/7i8xD4taZie/PNSFZ29g=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,86 @@
+// Package config loads .rapg.toml — the per-project file that scopes which
+// secrets `rapg run` injects into a child process.
+//
+// File schema:
+//
+//	# .rapg.toml
+//	namespace = "myapp"          # required: matches PasswordEntry.Namespace
+//	keys = ["DATABASE_URL", ...] # optional: explicit env-key whitelist;
+//	                             # if omitted, all entries in the namespace
+//	                             # whose Env Key is non-empty are injected.
+//
+// Discovery: the loader walks up from a starting directory looking for
+// `.rapg.toml`, stopping at the filesystem root. The first match wins.
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+
+	"github.com/BurntSushi/toml"
+)
+
+// Filename is the file rapg looks for in the project hierarchy.
+const Filename = ".rapg.toml"
+
+// Project is the parsed contents of .rapg.toml.
+type Project struct {
+	Namespace string   `toml:"namespace"`
+	Keys      []string `toml:"keys,omitempty"`
+}
+
+// Allows reports whether the given env key is permitted by this project's
+// keys whitelist. An empty Keys list means "no whitelist" — all keys allowed.
+func (p *Project) Allows(envKey string) bool {
+	if len(p.Keys) == 0 {
+		return true
+	}
+	return slices.Contains(p.Keys, envKey)
+}
+
+// ErrNotFound is returned when no .rapg.toml exists in the directory chain.
+// Callers treat this as "no project context" — `rapg run` falls back to
+// injecting all env-tagged secrets in the global (empty) namespace.
+var ErrNotFound = errors.New("no .rapg.toml found in directory chain")
+
+// Find walks up from startDir looking for .rapg.toml. It stops at the
+// filesystem root. Returns the parsed project and the absolute path to the
+// file, or ErrNotFound.
+func Find(startDir string) (*Project, string, error) {
+	dir, err := filepath.Abs(startDir)
+	if err != nil {
+		return nil, "", err
+	}
+
+	for {
+		candidate := filepath.Join(dir, Filename)
+		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+			p, err := load(candidate)
+			if err != nil {
+				return nil, candidate, err
+			}
+			return p, candidate, nil
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			// Reached filesystem root.
+			return nil, "", ErrNotFound
+		}
+		dir = parent
+	}
+}
+
+func load(path string) (*Project, error) {
+	var p Project
+	if _, err := toml.DecodeFile(path, &p); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if p.Namespace == "" {
+		return nil, fmt.Errorf("%s: 'namespace' is required", path)
+	}
+	return &p, nil
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,9 +33,19 @@ type Project struct {
 }
 
 // Allows reports whether the given env key is permitted by this project's
-// keys whitelist. An empty Keys list means "no whitelist" — all keys allowed.
+// keys whitelist.
+//
+//   - Keys omitted from .rapg.toml entirely (nil slice)  → no whitelist,
+//     all keys allowed.
+//   - Keys = []  (explicit empty slice in TOML)          → whitelist is
+//     active and matches nothing — deny all.
+//   - Keys = ["A", "B", ...]                              → standard
+//     whitelist match.
+//
+// BurntSushi/toml preserves the nil/non-nil distinction (verified), so
+// "I want this project recognized but inject nothing" is expressible.
 func (p *Project) Allows(envKey string) bool {
-	if len(p.Keys) == 0 {
+	if p.Keys == nil {
 		return true
 	}
 	return slices.Contains(p.Keys, envKey)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,6 +30,11 @@ const Filename = ".rapg.toml"
 type Project struct {
 	Namespace string   `toml:"namespace"`
 	Keys      []string `toml:"keys,omitempty"`
+	// InheritGlobal, when true, also injects entries with empty Namespace
+	// (the 'global' bucket) on top of namespace-matched entries. Project
+	// entries take precedence on env-key collision. Defaults to false —
+	// strict isolation, which is the safer default for the agent narrative.
+	InheritGlobal bool `toml:"inherit_global,omitempty"`
 }
 
 // Allows reports whether the given env key is permitted by this project's

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,75 @@
+package config
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func TestFind_walksUp(t *testing.T) {
+	root := t.TempDir()
+	deep := filepath.Join(root, "a", "b", "c")
+	if err := os.MkdirAll(deep, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(root, Filename), "namespace = \"myapp\"\n")
+
+	p, path, err := Find(deep)
+	if err != nil {
+		t.Fatalf("Find: %v", err)
+	}
+	if p.Namespace != "myapp" {
+		t.Errorf("Namespace = %q, want %q", p.Namespace, "myapp")
+	}
+	if filepath.Dir(path) != root {
+		t.Errorf("found at %q, want under %q", path, root)
+	}
+}
+
+func TestFind_notFound(t *testing.T) {
+	root := t.TempDir()
+	_, _, err := Find(root)
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestFind_missingNamespace(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, Filename), "keys = [\"X\"]\n")
+
+	_, _, err := Find(root)
+	if err == nil {
+		t.Fatal("expected error for missing namespace, got nil")
+	}
+}
+
+func TestAllows(t *testing.T) {
+	cases := []struct {
+		name string
+		keys []string
+		key  string
+		want bool
+	}{
+		{"no whitelist allows everything", nil, "ANYTHING", true},
+		{"empty whitelist allows everything", []string{}, "ANYTHING", true},
+		{"whitelist hit", []string{"DB_URL", "API_KEY"}, "DB_URL", true},
+		{"whitelist miss", []string{"DB_URL"}, "API_KEY", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &Project{Keys: tc.keys}
+			if got := p.Allows(tc.key); got != tc.want {
+				t.Errorf("Allows(%q) = %v, want %v", tc.key, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -59,8 +59,8 @@ func TestAllows(t *testing.T) {
 		key  string
 		want bool
 	}{
-		{"no whitelist allows everything", nil, "ANYTHING", true},
-		{"empty whitelist allows everything", []string{}, "ANYTHING", true},
+		{"omitted (nil) allows everything", nil, "ANYTHING", true},
+		{"explicit empty whitelist denies everything", []string{}, "ANYTHING", false},
 		{"whitelist hit", []string{"DB_URL", "API_KEY"}, "DB_URL", true},
 		{"whitelist miss", []string{"DB_URL"}, "API_KEY", false},
 	}
@@ -71,5 +71,23 @@ func TestAllows(t *testing.T) {
 				t.Errorf("Allows(%q) = %v, want %v", tc.key, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestFind_explicitEmptyKeys confirms that BurntSushi/toml preserves the
+// nil-vs-empty distinction Allows() depends on.
+func TestFind_explicitEmptyKeys(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, Filename), "namespace = \"x\"\nkeys = []\n")
+
+	p, _, err := Find(root)
+	if err != nil {
+		t.Fatalf("Find: %v", err)
+	}
+	if p.Keys == nil {
+		t.Fatal("explicit 'keys = []' should round-trip as a non-nil empty slice")
+	}
+	if p.Allows("ANYTHING") {
+		t.Error("explicit empty whitelist should deny all keys")
 	}
 }

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -169,12 +169,22 @@ func GetEntry(entry storage.PasswordEntry) (*storage.SecretData, error) {
 // GetEnvVars retrieves the env-tagged secrets that should be injected into
 // a child process for the given project context.
 //
-//   - project == nil   → only entries with an empty Namespace ('global').
-//   - project != nil   → only entries whose Namespace matches project.Namespace,
-//     filtered further by project.Allows(EnvKey).
+//   - project == nil                      → only entries with an empty
+//     Namespace ('global').
+//   - project != nil, !InheritGlobal      → only entries whose Namespace
+//     matches project.Namespace.
+//   - project != nil, InheritGlobal=true  → global entries first, then
+//     namespace-matched entries (which override globals on env-key
+//     collision so the more-specific project value wins).
 //
-// This deliberately scopes secrets: an entry tagged for project A must never
-// leak into a run that has no project config or has project B's config.
+// In all project-context cases, project.Allows(EnvKey) further filters by
+// the optional whitelist.
+//
+// This deliberately scopes secrets: by default an entry tagged for project
+// A must never leak into a run that has no project config or has project
+// B's config. Opt into global inheritance via 'inherit_global = true' in
+// .rapg.toml when shared utility credentials (GITHUB_TOKEN etc.) are
+// genuinely cross-cutting.
 func GetEnvVars(project *config.Project) (map[string]string, error) {
 	if SessionKey == nil {
 		return nil, errors.New("vault locked")
@@ -186,26 +196,36 @@ func GetEnvVars(project *config.Project) (map[string]string, error) {
 	}
 
 	envVars := make(map[string]string)
-	for _, entry := range entries {
-		if project == nil {
-			if entry.Namespace != "" {
-				continue
-			}
-		} else {
-			if entry.Namespace != project.Namespace {
-				continue
-			}
-		}
 
-		secret, err := GetEntry(entry)
-		if err != nil || secret.EnvKey == "" {
-			continue
+	// collect decrypts entries matching `match` and writes them into envVars,
+	// applying the project keys whitelist when one is active.
+	collect := func(match func(storage.PasswordEntry) bool) {
+		for _, entry := range entries {
+			if !match(entry) {
+				continue
+			}
+			secret, err := GetEntry(entry)
+			if err != nil || secret.EnvKey == "" {
+				continue
+			}
+			if project != nil && !project.Allows(secret.EnvKey) {
+				continue
+			}
+			envVars[secret.EnvKey] = secret.Password
 		}
-		if project != nil && !project.Allows(secret.EnvKey) {
-			continue
-		}
-		envVars[secret.EnvKey] = secret.Password
 	}
+
+	if project == nil {
+		collect(func(e storage.PasswordEntry) bool { return e.Namespace == "" })
+		return envVars, nil
+	}
+
+	// Two-pass when inheriting: globals first, then namespace overrides.
+	// Single-pass otherwise.
+	if project.InheritGlobal {
+		collect(func(e storage.PasswordEntry) bool { return e.Namespace == "" })
+	}
+	collect(func(e storage.PasswordEntry) bool { return e.Namespace == project.Namespace })
 	return envVars, nil
 }
 

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -169,9 +169,9 @@ func GetEntry(entry storage.PasswordEntry) (*storage.SecretData, error) {
 // GetEnvVars retrieves the env-tagged secrets that should be injected into
 // a child process for the given project context.
 //
-// - project == nil   → only entries with an empty Namespace ('global').
-// - project != nil   → only entries whose Namespace matches project.Namespace,
-//                      filtered further by project.Allows(EnvKey).
+//   - project == nil   → only entries with an empty Namespace ('global').
+//   - project != nil   → only entries whose Namespace matches project.Namespace,
+//     filtered further by project.Allows(EnvKey).
 //
 // This deliberately scopes secrets: an entry tagged for project A must never
 // leak into a run that has no project config or has project B's config.

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -135,12 +135,13 @@ func GenerateRandomPassword(length int) (string, error) {
 	return string(ret), nil
 }
 
-// AddEntry encrypts and stores a password.
-func AddEntry(service, username string, data storage.SecretData) error {
+// AddEntry encrypts and stores a password. namespace may be empty
+// (means "global" / visible without a project config).
+func AddEntry(namespace, service, username string, data storage.SecretData) error {
 	if SessionKey == nil {
 		return errors.New("vault locked")
 	}
-	return storage.Create(service, username, data, SessionKey.Bytes(), crypto.EncryptAESGCM)
+	return storage.Create(namespace, service, username, data, SessionKey.Bytes(), crypto.EncryptAESGCM)
 }
 
 // GetEntry returns the decrypted secret data.

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 
 	"github.com/awnumar/memguard"
+	"github.com/kanywst/rapg/internal/config"
 	"github.com/kanywst/rapg/internal/crypto"
 	"github.com/kanywst/rapg/internal/storage"
 )
@@ -165,8 +166,16 @@ func GetEntry(entry storage.PasswordEntry) (*storage.SecretData, error) {
 	return &data, nil
 }
 
-// GetEnvVars retrieves all secrets that have an EnvKey set.
-func GetEnvVars() (map[string]string, error) {
+// GetEnvVars retrieves the env-tagged secrets that should be injected into
+// a child process for the given project context.
+//
+// - project == nil   → only entries with an empty Namespace ('global').
+// - project != nil   → only entries whose Namespace matches project.Namespace,
+//                      filtered further by project.Allows(EnvKey).
+//
+// This deliberately scopes secrets: an entry tagged for project A must never
+// leak into a run that has no project config or has project B's config.
+func GetEnvVars(project *config.Project) (map[string]string, error) {
 	if SessionKey == nil {
 		return nil, errors.New("vault locked")
 	}
@@ -178,13 +187,24 @@ func GetEnvVars() (map[string]string, error) {
 
 	envVars := make(map[string]string)
 	for _, entry := range entries {
+		if project == nil {
+			if entry.Namespace != "" {
+				continue
+			}
+		} else {
+			if entry.Namespace != project.Namespace {
+				continue
+			}
+		}
+
 		secret, err := GetEntry(entry)
-		if err != nil {
-			continue // Skip corrupted entries
+		if err != nil || secret.EnvKey == "" {
+			continue
 		}
-		if secret.EnvKey != "" {
-			envVars[secret.EnvKey] = secret.Password
+		if project != nil && !project.Allows(secret.EnvKey) {
+			continue
 		}
+		envVars[secret.EnvKey] = secret.Password
 	}
 	return envVars, nil
 }

--- a/internal/core/core_test.go
+++ b/internal/core/core_test.go
@@ -188,6 +188,58 @@ func TestGetEnvVars_namespaceScoping(t *testing.T) {
 	}
 }
 
+func TestGetEnvVars_inheritGlobal(t *testing.T) {
+	cleanup := setupCoreTest(t)
+	defer cleanup()
+	InitializeVault([]byte("p"))
+
+	// Global utility secret + proj-a secrets.
+	AddEntry("", "github", "u", storage.SecretData{Password: "ghp_global", EnvKey: "GITHUB_TOKEN"})
+	AddEntry("proj-a", "anthropic", "u", storage.SecretData{Password: "ka", EnvKey: "ANTHROPIC_API_KEY"})
+
+	// Without inherit_global → only proj-a entries.
+	got, err := GetEnvVars(&config.Project{Namespace: "proj-a"})
+	if err != nil {
+		t.Fatalf("GetEnvVars: %v", err)
+	}
+	if _, ok := got["GITHUB_TOKEN"]; ok {
+		t.Errorf("global GITHUB_TOKEN leaked into strict-isolation run: %#v", got)
+	}
+	if got["ANTHROPIC_API_KEY"] != "ka" {
+		t.Errorf("proj-a ANTHROPIC_API_KEY missing: %#v", got)
+	}
+
+	// With inherit_global → global GITHUB_TOKEN visible alongside proj-a.
+	got, err = GetEnvVars(&config.Project{Namespace: "proj-a", InheritGlobal: true})
+	if err != nil {
+		t.Fatalf("GetEnvVars(inherit): %v", err)
+	}
+	if got["GITHUB_TOKEN"] != "ghp_global" {
+		t.Errorf("inherited GITHUB_TOKEN missing or wrong: %#v", got)
+	}
+	if got["ANTHROPIC_API_KEY"] != "ka" {
+		t.Errorf("proj-a ANTHROPIC_API_KEY missing: %#v", got)
+	}
+}
+
+func TestGetEnvVars_inheritGlobal_projectOverridesGlobal(t *testing.T) {
+	cleanup := setupCoreTest(t)
+	defer cleanup()
+	InitializeVault([]byte("p"))
+
+	// Same env key in global and proj-a — project value must win.
+	AddEntry("", "github", "u", storage.SecretData{Password: "ghp_GLOBAL", EnvKey: "GITHUB_TOKEN"})
+	AddEntry("proj-a", "github", "u", storage.SecretData{Password: "ghp_PROJECT", EnvKey: "GITHUB_TOKEN"})
+
+	got, err := GetEnvVars(&config.Project{Namespace: "proj-a", InheritGlobal: true})
+	if err != nil {
+		t.Fatalf("GetEnvVars: %v", err)
+	}
+	if got["GITHUB_TOKEN"] != "ghp_PROJECT" {
+		t.Errorf("project value should override global on key collision; got %q", got["GITHUB_TOKEN"])
+	}
+}
+
 func TestGenerateRandomPassword(t *testing.T) {
 	p1, err := GenerateRandomPassword(16)
 	if err != nil {

--- a/internal/core/core_test.go
+++ b/internal/core/core_test.go
@@ -93,7 +93,7 @@ func TestEntryManagement(t *testing.T) {
 	}
 
 	// Add
-	if err := AddEntry(svc, user, data); err != nil {
+	if err := AddEntry("", svc, user, data); err != nil {
 		t.Fatalf("AddEntry failed: %v", err)
 	}
 
@@ -122,9 +122,9 @@ func TestEnvVars(t *testing.T) {
 	defer cleanup()
 	InitializeVault([]byte("p"))
 
-	AddEntry("db", "user", storage.SecretData{Password: "postgres://...", EnvKey: "DATABASE_URL"})
-	AddEntry("api", "key", storage.SecretData{Password: "12345", EnvKey: "API_KEY"})
-	AddEntry("other", "foo", storage.SecretData{Password: "ignored", EnvKey: ""})
+	AddEntry("", "db", "user", storage.SecretData{Password: "postgres://...", EnvKey: "DATABASE_URL"})
+	AddEntry("", "api", "key", storage.SecretData{Password: "12345", EnvKey: "API_KEY"})
+	AddEntry("", "other", "foo", storage.SecretData{Password: "ignored", EnvKey: ""})
 
 	vars, err := GetEnvVars()
 	if err != nil {

--- a/internal/core/core_test.go
+++ b/internal/core/core_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"testing"
 
+	"github.com/kanywst/rapg/internal/config"
 	"github.com/kanywst/rapg/internal/storage"
 )
 
@@ -126,7 +127,7 @@ func TestEnvVars(t *testing.T) {
 	AddEntry("", "api", "key", storage.SecretData{Password: "12345", EnvKey: "API_KEY"})
 	AddEntry("", "other", "foo", storage.SecretData{Password: "ignored", EnvKey: ""})
 
-	vars, err := GetEnvVars()
+	vars, err := GetEnvVars(nil)
 	if err != nil {
 		t.Fatalf("GetEnvVars failed: %v", err)
 	}
@@ -136,6 +137,54 @@ func TestEnvVars(t *testing.T) {
 	}
 	if vars["DATABASE_URL"] != "postgres://..." {
 		t.Error("DATABASE_URL mismatch")
+	}
+}
+
+func TestGetEnvVars_namespaceScoping(t *testing.T) {
+	cleanup := setupCoreTest(t)
+	defer cleanup()
+	InitializeVault([]byte("p"))
+
+	// Two namespaces + one global entry, all env-tagged.
+	AddEntry("", "global-db", "u", storage.SecretData{Password: "g", EnvKey: "GLOBAL_KEY"})
+	AddEntry("proj-a", "db", "u", storage.SecretData{Password: "a", EnvKey: "DB_URL"})
+	AddEntry("proj-a", "anthropic", "u", storage.SecretData{Password: "ka", EnvKey: "ANTHROPIC_API_KEY"})
+	AddEntry("proj-b", "db", "u", storage.SecretData{Password: "b", EnvKey: "DB_URL"})
+
+	// nil project → only the global entry.
+	got, err := GetEnvVars(nil)
+	if err != nil {
+		t.Fatalf("GetEnvVars(nil): %v", err)
+	}
+	if len(got) != 1 || got["GLOBAL_KEY"] != "g" {
+		t.Errorf("nil project leaked or missed entries: %#v", got)
+	}
+
+	// proj-a, no whitelist → all proj-a env-tagged entries.
+	got, err = GetEnvVars(&config.Project{Namespace: "proj-a"})
+	if err != nil {
+		t.Fatalf("GetEnvVars(proj-a): %v", err)
+	}
+	if len(got) != 2 || got["DB_URL"] != "a" || got["ANTHROPIC_API_KEY"] != "ka" {
+		t.Errorf("proj-a got: %#v", got)
+	}
+
+	// proj-a with whitelist → only DB_URL passes.
+	got, err = GetEnvVars(&config.Project{Namespace: "proj-a", Keys: []string{"DB_URL"}})
+	if err != nil {
+		t.Fatalf("GetEnvVars(proj-a, whitelist): %v", err)
+	}
+	if len(got) != 1 || got["DB_URL"] != "a" {
+		t.Errorf("proj-a whitelist got: %#v", got)
+	}
+
+	// proj-b → its own DB_URL, not proj-a's.
+	got, err = GetEnvVars(&config.Project{Namespace: "proj-b"})
+	if err != nil {
+		t.Fatalf("GetEnvVars(proj-b): %v", err)
+	}
+	if got["DB_URL"] != "b" {
+		t.Errorf("proj-b DB_URL = %q, want %q", got["DB_URL"], "b")
 	}
 }
 

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -20,11 +20,15 @@ type SecretData struct {
 	EnvKey   string `json:"env_key,omitempty"`
 }
 
+// PasswordEntry is one row in the vault. Namespace scopes the entry to a
+// project (matched by .rapg.toml). An empty Namespace means "global" — visible
+// to any `rapg run` invocation that has no project config.
 type PasswordEntry struct {
 	gorm.Model
-	Service  string `gorm:"uniqueIndex:idx_service_username"`
-	Username string `gorm:"uniqueIndex:idx_service_username"`
-	// Cipher contains the encrypted JSON of SecretData
+	Namespace string `gorm:"uniqueIndex:idx_namespace_service_username,priority:1"`
+	Service   string `gorm:"uniqueIndex:idx_namespace_service_username,priority:2"`
+	Username  string `gorm:"uniqueIndex:idx_namespace_service_username,priority:3"`
+	// Cipher contains the encrypted JSON of SecretData.
 	Cipher []byte
 }
 
@@ -59,6 +63,12 @@ func InitDB() error {
 		return fmt.Errorf("failed to migrate database: %w", err)
 	}
 
+	// Pre-v4 schemas had a unique index on (Service, Username). v4 widens
+	// uniqueness to (Namespace, Service, Username) so the same Service can
+	// exist in multiple project namespaces. Drop the legacy index if present;
+	// safe to ignore the error on fresh DBs that never had it.
+	db.Exec("DROP INDEX IF EXISTS idx_service_username")
+
 	DB = db
 	return nil
 }
@@ -79,7 +89,7 @@ func GetMeta(key string) ([]byte, error) {
 
 // Entry Operations
 
-func Create(service, username string, secret SecretData, key []byte, encryptFunc func([]byte, []byte) ([]byte, error)) error {
+func Create(namespace, service, username string, secret SecretData, key []byte, encryptFunc func([]byte, []byte) ([]byte, error)) error {
 	// #nosec G117 -- The marshaled struct contains a "Password" field but
 	// it is immediately encrypted with AES-256-GCM by encryptFunc on the
 	// next line. Plaintext never leaves this stack frame.
@@ -94,9 +104,10 @@ func Create(service, username string, secret SecretData, key []byte, encryptFunc
 	}
 
 	entry := PasswordEntry{
-		Service:  service,
-		Username: username,
-		Cipher:   encrypted,
+		Namespace: namespace,
+		Service:   service,
+		Username:  username,
+		Cipher:    encrypted,
 	}
 	return DB.Create(&entry).Error
 }
@@ -115,9 +126,20 @@ func Delete(id uint) error {
 	return DB.Unscoped().Delete(&PasswordEntry{}, id).Error
 }
 
-func Find(service, username string) (*PasswordEntry, error) {
+func Find(namespace, service, username string) (*PasswordEntry, error) {
 	var entry PasswordEntry
-	if err := DB.Where("service = ? AND username = ?", service, username).First(&entry).Error; err != nil {
+	if err := DB.Where("namespace = ? AND service = ? AND username = ?", namespace, service, username).First(&entry).Error; err != nil {
+		return nil, err
+	}
+	return &entry, nil
+}
+
+// FindByID returns a single entry by its primary key. Used by callers that
+// already hold an ID (e.g., the TUI selection list) and don't need to
+// re-query by composite keys that are no longer globally unique.
+func FindByID(id uint) (*PasswordEntry, error) {
+	var entry PasswordEntry
+	if err := DB.First(&entry, id).Error; err != nil {
 		return nil, err
 	}
 	return &entry, nil

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -65,9 +65,13 @@ func InitDB() error {
 
 	// Pre-v4 schemas had a unique index on (Service, Username). v4 widens
 	// uniqueness to (Namespace, Service, Username) so the same Service can
-	// exist in multiple project namespaces. Drop the legacy index if present;
-	// safe to ignore the error on fresh DBs that never had it.
-	db.Exec("DROP INDEX IF EXISTS idx_service_username")
+	// exist in multiple project namespaces. Drop the legacy index if present.
+	// IF EXISTS makes it a no-op on fresh DBs; any other error (lock,
+	// corruption) is surfaced as a startup warning so it isn't silently
+	// swallowed.
+	if err := db.Exec("DROP INDEX IF EXISTS idx_service_username").Error; err != nil {
+		fmt.Fprintf(os.Stderr, "[rapg] warning: could not drop legacy idx_service_username: %v\n", err)
+	}
 
 	DB = db
 	return nil

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -143,4 +143,3 @@ func TestNamespaceUniqueness(t *testing.T) {
 		t.Errorf("Find returned the same row across namespaces: %d", a.ID)
 	}
 }
-

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -67,13 +67,13 @@ func TestEntryOperations(t *testing.T) {
 	secret := SecretData{Password: "password123"}
 	dummyKey := []byte("dummy")
 
-	// Test Create
-	if err := Create(svc, user, secret, dummyKey, mockEncrypt); err != nil {
+	// Test Create (namespace empty = global)
+	if err := Create("", svc, user, secret, dummyKey, mockEncrypt); err != nil {
 		t.Fatalf("Create failed: %v", err)
 	}
 
 	// Test Find
-	entry, err := Find(svc, user)
+	entry, err := Find("", svc, user)
 	if err != nil {
 		t.Fatalf("Find failed: %v", err)
 	}
@@ -109,3 +109,38 @@ func TestEntryOperations(t *testing.T) {
 		t.Errorf("Delete should hard-delete the row, but %d row(s) remain in the table", count)
 	}
 }
+
+func TestNamespaceUniqueness(t *testing.T) {
+	cleanup := setupTestDB(t)
+	defer cleanup()
+
+	noop := func(data, _ []byte) ([]byte, error) { return data, nil }
+	secret := SecretData{Password: "x"}
+
+	// Same (service, username) in two different namespaces must coexist.
+	if err := Create("proj-a", "postgres", "app", secret, []byte("k"), noop); err != nil {
+		t.Fatalf("Create in proj-a failed: %v", err)
+	}
+	if err := Create("proj-b", "postgres", "app", secret, []byte("k"), noop); err != nil {
+		t.Fatalf("Create in proj-b should succeed across namespaces: %v", err)
+	}
+
+	// Same (namespace, service, username) must collide.
+	if err := Create("proj-a", "postgres", "app", secret, []byte("k"), noop); err == nil {
+		t.Error("Create with duplicate (namespace, service, username) should fail")
+	}
+
+	// Find scoped by namespace returns the right row.
+	a, err := Find("proj-a", "postgres", "app")
+	if err != nil {
+		t.Fatalf("Find in proj-a failed: %v", err)
+	}
+	b, err := Find("proj-b", "postgres", "app")
+	if err != nil {
+		t.Fatalf("Find in proj-b failed: %v", err)
+	}
+	if a.ID == b.ID {
+		t.Errorf("Find returned the same row across namespaces: %d", a.ID)
+	}
+}
+

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -324,7 +324,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 func (m *Model) loadSelectedDetail() {
 	if i, ok := m.list.SelectedItem().(item); ok {
-		entry, err := storage.Find(i.service, i.username)
+		entry, err := storage.FindByID(i.id)
 		if err == nil {
 			secret, err := core.GetEntry(*entry)
 			if err == nil {
@@ -400,7 +400,9 @@ func (m *Model) submitAdd() tea.Cmd {
 		Notes:    notes,
 	}
 
-	if err := core.AddEntry(service, username, data); err != nil {
+	// Namespace stays empty in the TUI form for now; project-scoped entries
+	// will be added in PR-B's TUI commit.
+	if err := core.AddEntry("", service, username, data); err != nil {
 		return m.flashMessage("Add failed: " + err.Error())
 	}
 	m.list.SetItems(loadItems())

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -52,14 +52,20 @@ const (
 )
 
 type item struct {
-	id       uint
-	service  string
-	username string
+	id        uint
+	service   string
+	username  string
+	namespace string
 }
 
-func (i item) Title() string       { return i.service }
-func (i item) Description() string { return i.username }
-func (i item) FilterValue() string { return i.service + " " + i.username }
+func (i item) Title() string { return i.service }
+func (i item) Description() string {
+	if i.namespace != "" {
+		return i.username + " • " + i.namespace
+	}
+	return i.username
+}
+func (i item) FilterValue() string { return i.service + " " + i.username + " " + i.namespace }
 
 type Model struct {
 	state         sessionState
@@ -72,6 +78,7 @@ type Model struct {
 	windowHeight  int
 
 	// Detail View
+	selectedEntry  *storage.PasswordEntry
 	selectedSecret *storage.SecretData
 	viewport       viewport.Model
 
@@ -88,9 +95,21 @@ func NewModel() Model {
 	l.SetFilteringEnabled(true)
 	l.Styles.Title = titleStyle
 
-	// Add Form Inputs
-	inputs := make([]textinput.Model, 6)
-	labels := []string{"Service", "Username", "Password (Empty to Gen)", "TOTP Secret (Optional)", "Env Key (e.g. DATABASE_URL)", "Notes"}
+	// Add Form Inputs.
+	// Namespace sits next to Env Key — both are env-injection metadata.
+	// An entry with Namespace="" is global; otherwise it is only injected
+	// when 'rapg run' is invoked from a directory whose .rapg.toml declares
+	// the same namespace.
+	inputs := make([]textinput.Model, 7)
+	labels := []string{
+		"Service",
+		"Username",
+		"Password (Empty to Gen)",
+		"TOTP Secret (Optional)",
+		"Namespace (Optional, e.g. myapp)",
+		"Env Key (e.g. DATABASE_URL)",
+		"Notes",
+	}
 
 	for i := range inputs {
 		inputs[i] = textinput.New()
@@ -129,7 +148,7 @@ func loadItems() []list.Item {
 	}
 	items := make([]list.Item, len(entries))
 	for i, e := range entries {
-		items[i] = item{id: e.ID, service: e.Service, username: e.Username}
+		items[i] = item{id: e.ID, service: e.Service, username: e.Username, namespace: e.Namespace}
 	}
 	return items
 }
@@ -232,6 +251,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			case "up", "k", "down", "j":
 				m.list, cmd = m.list.Update(msg)
 				// Clear detail view on navigation to avoid lag from decryption
+				m.selectedEntry = nil
 				m.selectedSecret = nil
 				m.viewport.SetContent("")
 				return m, cmd
@@ -328,6 +348,7 @@ func (m *Model) loadSelectedDetail() {
 		if err == nil {
 			secret, err := core.GetEntry(*entry)
 			if err == nil {
+				m.selectedEntry = entry
 				m.selectedSecret = secret
 				m.updateDetailView()
 			}
@@ -345,6 +366,11 @@ func (m *Model) updateDetailView() {
 	var b strings.Builder
 
 	b.WriteString(titleStyle.Render("DETAILS") + "\n\n")
+
+	// Namespace (if set on the entry)
+	if m.selectedEntry != nil && m.selectedEntry.Namespace != "" {
+		b.WriteString(labelStyle.Render("Namespace:") + " " + valueStyle.Render(m.selectedEntry.Namespace) + "\n")
+	}
 
 	// Password
 	b.WriteString(labelStyle.Render("Password: ") + valueStyle.Render("••••••••") + " (Enter to copy)\n")
@@ -378,8 +404,9 @@ func (m *Model) submitAdd() tea.Cmd {
 	username := m.inputs[1].Value()
 	pass := m.inputs[2].Value()
 	totpSecret := m.inputs[3].Value()
-	envKey := m.inputs[4].Value()
-	notes := m.inputs[5].Value()
+	namespace := m.inputs[4].Value()
+	envKey := m.inputs[5].Value()
+	notes := m.inputs[6].Value()
 
 	if service == "" || username == "" {
 		return nil
@@ -400,9 +427,7 @@ func (m *Model) submitAdd() tea.Cmd {
 		Notes:    notes,
 	}
 
-	// Namespace stays empty in the TUI form for now; project-scoped entries
-	// will be added in PR-B's TUI commit.
-	if err := core.AddEntry("", service, username, data); err != nil {
+	if err := core.AddEntry(namespace, service, username, data); err != nil {
 		return m.flashMessage("Add failed: " + err.Error())
 	}
 	m.list.SetItems(loadItems())


### PR DESCRIPTION
## Summary

PR-B of 3 for v4.0. Adds **project-scoped secrets** via `.rapg.toml` — the day-1 use loop for the AI-agent narrative.

```toml
# .rapg.toml at repo root
namespace = "myapp"
keys = ["DATABASE_URL", "ANTHROPIC_API_KEY"]  # optional whitelist
```

```bash
cd ~/code/myapp
rapg run -- claude code
# [rapg] project: myapp (/Users/me/code/myapp/.rapg.toml)
# child sees only myapp's namespaced secrets (and only the listed keys if whitelisted)
```

PR-C (`rapg redact` + `rapg session log`) follows.

### What changed (commit by commit)

1. `4b86074` — **`storage`**: new `Namespace` field on `PasswordEntry`. Unique index widens to `(Namespace, Service, Username)` so the same `Service`/`Username` pair can exist across projects. Legacy `idx_service_username` is dropped via `DROP INDEX IF EXISTS` after AutoMigrate. New `storage.FindByID` for callers (TUI) that already hold an ID.
2. `6d0e75d` — **`ui`**: 7th input `Namespace (Optional)` in the add form. Detail view shows the namespace; list item description shows `username • namespace`.
3. `c448004` — **`internal/config`**: `.rapg.toml` parser. Walks up from cwd to `/`. `BurntSushi/toml v1.6.0` added as direct dep.
4. `de2ecb3` — **`cmd`**: `rapg run` and `rapg export` now load the project via `loadProject()` and pass it to `core.GetEnvVars(*config.Project)`. Resolution: nil → global only; non-nil → namespace + key whitelist.
5. `e7e18f9` — **`cmd`**: new `rapg project` (script-friendly namespace printer) and `rapg hook <shell>` (zsh/bash/fish snippet that announces project entry/exit on `cd`). Informational only — no auto-injection.
6. `2bd165d` — **`docs`**: README adds `.rapg.toml`, Namespace, and hook sections. Roadmap reorders.

### Breaking changes (intentional, per project owner)

- `core.AddEntry`, `storage.Create`, `storage.Find`, and `core.GetEnvVars` all gain a leading `namespace` / `*config.Project` parameter.
- `rapg run` and `rapg export` now scope by project: namespaced entries are invisible to runs without a `.rapg.toml` (and vice versa).
- DB schema migrates in place (column add + index swap). Existing entries get empty namespace = "global", visible to all `rapg run` invocations that have no project config.

### Why hook is informational only

Direnv-style auto-injection requires an in-shell key cache (or a daemon) that holds the unlocked vault key. Doing that safely is a separate problem (TPM / Touch ID / Secure Enclave on macOS, dbus secret-service on Linux). Shipping a half-baked solution that writes the key to a tmpfile or env var would defeat the whole "secrets never touch disk" pitch. Roadmap item #4 carves out the proper solution.

## Test plan

- [x] `go build ./...` clean
- [x] `go test -race ./...` all green (new tests: namespace uniqueness in storage, namespace scoping in core, .rapg.toml walk + Allows in config)
- [x] `go vet`, `staticcheck`, `gosec` (0 issues), `govulncheck` (0 vulns) all clean
- [x] `npx markdownlint-cli2 README.md` — 0 errors
- [x] Manual smoke: `rapg project` returns namespace from a temp `.rapg.toml`; `rapg hook zsh|bash|fish` produces sourceable snippets