### PR TITLE
v4 (PR-C): rapg redact + rapg session log

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,14 +123,44 @@ After installing, `cd` between project directories prints:
 [rapg] left project: myapp
 ```
 
+## Transcript hygiene (`rapg redact`)
+
+Before pasting an agent transcript into a bug report, scrub vault values from it:
+
+```bash
+rapg redact ~/.claude/transcripts/today.jsonl > redacted.jsonl
+# or, against the clipboard:
+pbpaste | rapg redact - | pbcopy
+```
+
+Each occurrence of a vault `Password` becomes `[REDACTED:<env_key>]` (or `[REDACTED:<service>/<username>]` if the entry has no env key). Values shorter than 8 characters are skipped to avoid false positives. The match count is reported on stderr so it doesn't contaminate the redacted output stream.
+
+Scope is the whole vault, regardless of `.rapg.toml` — when checking a transcript, you want maximum coverage, not project boundaries.
+
+## Audit log (`rapg session log`)
+
+Every `rapg run -- <cmd>` appends one line to `~/.rapg/sessions.jsonl` recording the command, project namespace, env keys injected (**not** their values), exit code, pid, and cwd. Read the trail back:
+
+```bash
+rapg session log
+# 2026-05-05 14:30:12  [myapp]  claude code --print  exit=0  keys: ANTHROPIC_API_KEY,DB_URL
+# 2026-05-05 14:32:05  [-]       npm run dev          exit=0  keys: -
+
+rapg session log --limit 100
+```
+
+The log is plaintext metadata at mode `0600`. To wipe it, just `rm ~/.rapg/sessions.jsonl` — `rapg run` will recreate it on the next invocation.
+
 ## Subcommands
 
 | Command | Purpose |
 | --- | --- |
 | `rapg` | Launch the TUI |
-| `rapg run -- <cmd>` | Inject secrets into a child process (respects `.rapg.toml`) |
+| `rapg run -- <cmd>` | Inject secrets into a child process (respects `.rapg.toml`, records to session log) |
 | `rapg gen [length]` | Generate a cryptographically random password |
 | `rapg export` | Print env-tagged secrets as `KEY=value` lines (respects `.rapg.toml`) |
+| `rapg redact <file\|->` | Mask vault values in a file or stdin; output to stdout |
+| `rapg session log` | Show recent `rapg run` sessions from `~/.rapg/sessions.jsonl` |
 | `rapg project` | Print the current project's namespace; exit 1 if not in a project |
 | `rapg hook <shell>` | Print a `cd` notifier snippet for `zsh` / `bash` / `fish` |
 | `rapg nuke` | Wipe the local vault after confirmation |
@@ -139,10 +169,8 @@ After installing, `cd` between project directories prints:
 
 Next on the agent-leakage track:
 
-1. `rapg redact <file>` — scan a file for vault values and mask them; use this on agent transcripts before sharing.
-2. `rapg session log` — audit which command saw which secret and when.
-3. `rapg proxy --provider anthropic|openai` (experimental) — local HTTP proxy that holds the real API key, so agents only ever see a short-lived proxy token.
-4. Direnv-style auto-injection on `cd`, with a TPM / Touch ID / Secure Enclave-backed key cache.
+1. `rapg proxy --provider anthropic|openai` (experimental) — local HTTP proxy that holds the real API key, so agents only ever see a short-lived proxy token.
+2. Direnv-style auto-injection on `cd`, with a TPM / Touch ID / Secure Enclave-backed key cache.
 
 ## Security
 

--- a/cmd/rapg/main.go
+++ b/cmd/rapg/main.go
@@ -359,6 +359,8 @@ func runRedact(target string) {
 	if target == "-" {
 		input, err = io.ReadAll(os.Stdin)
 	} else {
+		// #nosec G304 -- target is the file the user explicitly asked
+		// rapg to redact; the user IS the trust boundary in a CLI tool.
 		input, err = os.ReadFile(target)
 	}
 	if err != nil {

--- a/cmd/rapg/main.go
+++ b/cmd/rapg/main.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/awnumar/memguard"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/kanywst/rapg/internal/audit"
 	"github.com/kanywst/rapg/internal/config"
 	"github.com/kanywst/rapg/internal/core"
 	"github.com/kanywst/rapg/internal/storage"
@@ -169,15 +170,21 @@ Note: Secrets configured in Rapg will override any existing environment variable
 				runCmd.Env = append(runCmd.Env, fmt.Sprintf("%s=%s", k, v))
 			}
 
-			if err := runCmd.Run(); err != nil {
-				// ProcessState.ExitCode() is portable across Linux/macOS/Windows
-				// and returns -1 if the process did not exit normally.
+			runErr := runCmd.Run()
+
+			// Build the audit record AFTER the child exits so we have the
+			// real ProcessState.ExitCode(). Failures to write the log are
+			// non-fatal (logged to stderr) — auditing should never block
+			// the actual run.
+			recordSession(project, command, cmdArgs, envVars, runCmd)
+
+			if runErr != nil {
 				if runCmd.ProcessState != nil {
 					if code := runCmd.ProcessState.ExitCode(); code >= 0 {
 						os.Exit(code)
 					}
 				}
-				fmt.Fprintf(os.Stderr, "Command execution failed: %v\n", err)
+				fmt.Fprintf(os.Stderr, "Command execution failed: %v\n", runErr)
 				os.Exit(1)
 			}
 		},
@@ -265,6 +272,37 @@ func unlockVault() {
 	if err := core.UnlockVault(passwordBuffer.Bytes()); err != nil {
 		fmt.Fprintln(os.Stderr, "Invalid password.")
 		os.Exit(1)
+	}
+}
+
+// recordSession appends one entry to ~/.rapg/sessions.jsonl describing the
+// command we just ran and which env keys were injected. Failures here are
+// non-fatal — auditing must not block the actual run.
+func recordSession(project *config.Project, command string, args []string, envVars map[string]string, runCmd *exec.Cmd) {
+	keys := make([]string, 0, len(envVars))
+	for k := range envVars {
+		keys = append(keys, k)
+	}
+
+	s := audit.Session{
+		Command:  command,
+		Args:     args,
+		EnvKeys:  keys,
+		ExitCode: -1,
+	}
+	if project != nil {
+		s.Namespace = project.Namespace
+	}
+	if runCmd.ProcessState != nil {
+		s.ExitCode = runCmd.ProcessState.ExitCode()
+		s.PID = runCmd.ProcessState.Pid()
+	}
+	if cwd, err := os.Getwd(); err == nil {
+		s.Cwd = cwd
+	}
+
+	if err := audit.Write(s); err != nil {
+		fmt.Fprintf(os.Stderr, "[rapg] warning: failed to write session log: %v\n", err)
 	}
 }
 

--- a/cmd/rapg/main.go
+++ b/cmd/rapg/main.go
@@ -342,10 +342,23 @@ func runRedact(target string) {
 		os.Exit(1)
 	}
 
-	var secrets []redact.Secret
+	var (
+		secrets []redact.Secret
+		skipped int
+	)
 	for _, e := range entries {
 		secret, err := core.GetEntry(e)
-		if err != nil || secret.Password == "" {
+		if err != nil {
+			// Decryption failure on a real entry is meaningful: the
+			// entry's value is in the vault but we couldn't read it,
+			// so anything matching it in the input is NOT going to
+			// get redacted. Surface it loudly so the user doesn't
+			// trust the output blindly.
+			fmt.Fprintf(os.Stderr, "[rapg] warning: skipping entry %q: %v\n", e.Service+"/"+e.Username, err)
+			skipped++
+			continue
+		}
+		if secret.Password == "" {
 			continue
 		}
 		label := secret.EnvKey
@@ -371,6 +384,17 @@ func runRedact(target string) {
 	out, n := redact.Redact(string(input), secrets)
 	fmt.Print(out)
 	fmt.Fprintf(os.Stderr, "[rapg] redacted %d distinct value(s) from %d candidate(s)\n", n, len(secrets))
+	if skipped > 0 {
+		fmt.Fprintf(os.Stderr, "[rapg] WARNING: %d entr%s could not be decrypted; output may still contain their values\n",
+			skipped, plural(skipped, "y", "ies"))
+	}
+}
+
+func plural(n int, singular, pluralForm string) string {
+	if n == 1 {
+		return singular
+	}
+	return pluralForm
 }
 
 // printSessions writes a tab-aligned, human-readable rendering of the

--- a/cmd/rapg/main.go
+++ b/cmd/rapg/main.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"text/tabwriter"
 
 	"github.com/awnumar/memguard"
 	tea "github.com/charmbracelet/bubbletea"
@@ -210,6 +211,35 @@ Designed for shell hooks — use 'rapg hook <shell>' to install one.`,
 		},
 	}
 
+	sessionCmd := &cobra.Command{
+		Use:   "session",
+		Short: "Inspect the rapg run audit log",
+	}
+	var sessionLimit int
+	sessionLogCmd := &cobra.Command{
+		Use:   "log",
+		Short: "Show recent rapg run sessions (most recent last)",
+		Long: `Print the audit trail of rapg run invocations from
+~/.rapg/sessions.jsonl. Each line records the command, project namespace,
+which env keys were injected (NOT their values), and the exit code.
+
+Default shows the last 20 entries; use --limit to widen.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			sessions, err := audit.Read(sessionLimit)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error reading session log: %v\n", err)
+				os.Exit(1)
+			}
+			if len(sessions) == 0 {
+				fmt.Fprintln(os.Stderr, "No sessions recorded yet. Run 'rapg run -- <cmd>' to populate the log.")
+				return
+			}
+			printSessions(sessions)
+		},
+	}
+	sessionLogCmd.Flags().IntVar(&sessionLimit, "limit", 20, "max number of recent sessions to show; <=0 means all")
+	sessionCmd.AddCommand(sessionLogCmd)
+
 	hookCmd := &cobra.Command{
 		Use:   "hook <shell>",
 		Short: "Print a shell hook that announces .rapg.toml projects on cd",
@@ -240,7 +270,7 @@ Install with:
 		},
 	}
 
-	rootCmd.AddCommand(genCmd, nukeCmd, exportCmd, runCmd, projectCmd, hookCmd)
+	rootCmd.AddCommand(genCmd, nukeCmd, exportCmd, runCmd, projectCmd, hookCmd, sessionCmd)
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
@@ -272,6 +302,34 @@ func unlockVault() {
 	if err := core.UnlockVault(passwordBuffer.Bytes()); err != nil {
 		fmt.Fprintln(os.Stderr, "Invalid password.")
 		os.Exit(1)
+	}
+}
+
+// printSessions writes a tab-aligned, human-readable rendering of the
+// session log to stdout. One line per session, ordered oldest to newest.
+func printSessions(sessions []audit.Session) {
+	tw := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	defer tw.Flush()
+	for _, s := range sessions {
+		ns := s.Namespace
+		if ns == "" {
+			ns = "-"
+		}
+		keys := strings.Join(s.EnvKeys, ",")
+		if keys == "" {
+			keys = "-"
+		}
+		cmdLine := s.Command
+		if len(s.Args) > 0 {
+			cmdLine += " " + strings.Join(s.Args, " ")
+		}
+		fmt.Fprintf(tw, "%s\t[%s]\t%s\texit=%d\tkeys: %s\n",
+			s.Timestamp.Local().Format("2006-01-02 15:04:05"),
+			ns,
+			cmdLine,
+			s.ExitCode,
+			keys,
+		)
 	}
 }
 

--- a/cmd/rapg/main.go
+++ b/cmd/rapg/main.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -17,6 +18,7 @@ import (
 	"github.com/kanywst/rapg/internal/audit"
 	"github.com/kanywst/rapg/internal/config"
 	"github.com/kanywst/rapg/internal/core"
+	"github.com/kanywst/rapg/internal/redact"
 	"github.com/kanywst/rapg/internal/storage"
 	"github.com/kanywst/rapg/internal/ui"
 	"github.com/spf13/cobra"
@@ -211,6 +213,28 @@ Designed for shell hooks — use 'rapg hook <shell>' to install one.`,
 		},
 	}
 
+	redactCmd := &cobra.Command{
+		Use:   "redact <file|->",
+		Short: "Mask vault values appearing in a file (use on agent transcripts before sharing)",
+		Long: `Read <file> (or stdin if '-') and replace every occurrence of any vault
+secret value with '[REDACTED:<label>]'. Output goes to stdout. Match count
+is reported to stderr.
+
+Scans every entry in the vault, regardless of namespace or .rapg.toml — the
+goal is maximum coverage when checking what a transcript might have leaked.
+Values shorter than 8 characters are skipped to avoid false positives like
+masking the word "test".
+
+Examples:
+
+    rapg redact ~/.claude/transcripts/today.jsonl > redacted.jsonl
+    pbpaste | rapg redact - | pbcopy`,
+		Args: cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			runRedact(args[0])
+		},
+	}
+
 	sessionCmd := &cobra.Command{
 		Use:   "session",
 		Short: "Inspect the rapg run audit log",
@@ -270,7 +294,7 @@ Install with:
 		},
 	}
 
-	rootCmd.AddCommand(genCmd, nukeCmd, exportCmd, runCmd, projectCmd, hookCmd, sessionCmd)
+	rootCmd.AddCommand(genCmd, nukeCmd, exportCmd, runCmd, projectCmd, hookCmd, sessionCmd, redactCmd)
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
@@ -303,6 +327,48 @@ func unlockVault() {
 		fmt.Fprintln(os.Stderr, "Invalid password.")
 		os.Exit(1)
 	}
+}
+
+// runRedact executes 'rapg redact <file|->'. It unlocks the vault, builds
+// a list of (value, label) pairs from every entry that has a non-empty
+// password, runs the redactor, and writes the masked output to stdout.
+// Match count goes to stderr so it never contaminates the output stream.
+func runRedact(target string) {
+	unlockVault()
+
+	entries, err := core.ListEntries()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error listing entries: %v\n", err)
+		os.Exit(1)
+	}
+
+	var secrets []redact.Secret
+	for _, e := range entries {
+		secret, err := core.GetEntry(e)
+		if err != nil || secret.Password == "" {
+			continue
+		}
+		label := secret.EnvKey
+		if label == "" {
+			label = e.Service + "/" + e.Username
+		}
+		secrets = append(secrets, redact.Secret{Value: secret.Password, Label: label})
+	}
+
+	var input []byte
+	if target == "-" {
+		input, err = io.ReadAll(os.Stdin)
+	} else {
+		input, err = os.ReadFile(target)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error reading input: %v\n", err)
+		os.Exit(1)
+	}
+
+	out, n := redact.Redact(string(input), secrets)
+	fmt.Print(out)
+	fmt.Fprintf(os.Stderr, "[rapg] redacted %d distinct value(s) from %d candidate(s)\n", n, len(secrets))
 }
 
 // printSessions writes a tab-aligned, human-readable rendering of the

--- a/cmd/rapg/main.go
+++ b/cmd/rapg/main.go
@@ -258,7 +258,12 @@ Default shows the last 20 entries; use --limit to widen.`,
 				fmt.Fprintln(os.Stderr, "No sessions recorded yet. Run 'rapg run -- <cmd>' to populate the log.")
 				return
 			}
-			printSessions(sessions)
+			if err := printSessions(sessions); err != nil {
+				// Most likely a broken pipe (e.g. piped to `head`).
+				// Exit quietly with non-zero so callers can detect it
+				// without flooding stderr.
+				os.Exit(1)
+			}
 		},
 	}
 	sessionLogCmd.Flags().IntVar(&sessionLimit, "limit", 20, "max number of recent sessions to show; <=0 means all")
@@ -399,9 +404,10 @@ func plural(n int, singular, pluralForm string) string {
 
 // printSessions writes a tab-aligned, human-readable rendering of the
 // session log to stdout. One line per session, ordered oldest to newest.
-func printSessions(sessions []audit.Session) {
+// Returns any error from writing to stdout (typically a broken pipe when
+// piped through `head` etc.) or from the tabwriter flush.
+func printSessions(sessions []audit.Session) error {
 	tw := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
-	defer tw.Flush()
 	for _, s := range sessions {
 		ns := s.Namespace
 		if ns == "" {
@@ -415,14 +421,17 @@ func printSessions(sessions []audit.Session) {
 		if len(s.Args) > 0 {
 			cmdLine += " " + strings.Join(s.Args, " ")
 		}
-		fmt.Fprintf(tw, "%s\t[%s]\t%s\texit=%d\tkeys: %s\n",
+		if _, err := fmt.Fprintf(tw, "%s\t[%s]\t%s\texit=%d\tkeys: %s\n",
 			s.Timestamp.Local().Format("2006-01-02 15:04:05"),
 			ns,
 			cmdLine,
 			s.ExitCode,
 			keys,
-		)
+		); err != nil {
+			return err
+		}
 	}
+	return tw.Flush()
 }
 
 // recordSession appends one entry to ~/.rapg/sessions.jsonl describing the

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -1,0 +1,126 @@
+// Package audit appends one JSON line per `rapg run` invocation to
+// ~/.rapg/sessions.jsonl, recording which env keys were injected into
+// which child process. The file is plaintext metadata — no secret values
+// are ever written. Use `rapg session log` to read it back.
+//
+// File format: one JSON object per line, sorted by append order. The schema
+// is intentionally additive — readers should ignore unknown fields.
+package audit
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+)
+
+// LogPath returns the absolute path to the session log under the user's
+// home directory. The parent directory is the same one used by storage.
+func LogPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".rapg", "sessions.jsonl"), nil
+}
+
+// Session is one row in the audit log.
+type Session struct {
+	Timestamp time.Time `json:"ts"`
+	Command   string    `json:"cmd"`
+	Args      []string  `json:"args,omitempty"`
+	Namespace string    `json:"namespace,omitempty"`
+	EnvKeys   []string  `json:"env_keys,omitempty"`
+	ExitCode  int       `json:"exit"`
+	PID       int       `json:"pid,omitempty"`
+	Cwd       string    `json:"cwd,omitempty"`
+}
+
+// Write appends one Session as JSON to the log. EnvKeys is sorted in place
+// so a downstream `rapg session log` shows stable output. The file is
+// created with mode 0600 if missing.
+func Write(s Session) error {
+	if s.Timestamp.IsZero() {
+		s.Timestamp = time.Now().UTC()
+	}
+	sort.Strings(s.EnvKeys)
+
+	path, err := LogPath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+
+	// O_APPEND on POSIX is atomic for writes <= PIPE_BUF; one JSON line is
+	// well under that, so concurrent `rapg run` invocations don't interleave.
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	line, err := json.Marshal(s)
+	if err != nil {
+		return err
+	}
+	line = append(line, '\n')
+	if _, err := f.Write(line); err != nil {
+		return fmt.Errorf("append session log: %w", err)
+	}
+	return nil
+}
+
+// Read returns the last `limit` sessions, oldest first. limit <= 0 returns
+// everything in the file.
+func Read(limit int) ([]Session, error) {
+	path, err := LogPath()
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	var all []Session
+	for _, line := range splitLines(data) {
+		if len(line) == 0 {
+			continue
+		}
+		var s Session
+		if err := json.Unmarshal(line, &s); err != nil {
+			// Skip malformed lines silently — the log is a best-effort
+			// audit trail, not authoritative state.
+			continue
+		}
+		all = append(all, s)
+	}
+	if limit > 0 && len(all) > limit {
+		all = all[len(all)-limit:]
+	}
+	return all, nil
+}
+
+// splitLines is a small helper that avoids pulling in bufio.Scanner just to
+// split on '\n'. Each returned slice references the original buffer.
+func splitLines(b []byte) [][]byte {
+	var out [][]byte
+	start := 0
+	for i, c := range b {
+		if c == '\n' {
+			out = append(out, b[start:i])
+			start = i + 1
+		}
+	}
+	if start < len(b) {
+		out = append(out, b[start:])
+	}
+	return out
+}

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -64,15 +64,22 @@ func Write(s Session) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
 
 	line, err := json.Marshal(s)
 	if err != nil {
+		_ = f.Close()
 		return err
 	}
 	line = append(line, '\n')
 	if _, err := f.Write(line); err != nil {
+		_ = f.Close()
 		return fmt.Errorf("append session log: %w", err)
+	}
+	// Surface Close errors explicitly: on some filesystems, write
+	// finalization (and thus the real I/O failure, if any) only happens
+	// at close time.
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close session log: %w", err)
 	}
 	return nil
 }

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -8,6 +8,7 @@
 package audit
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -77,23 +78,27 @@ func Write(s Session) error {
 }
 
 // Read returns the last `limit` sessions, oldest first. limit <= 0 returns
-// everything in the file.
+// everything in the file. Streams via bufio.Scanner with a sliding window
+// so memory stays bounded by `limit` even on large logs.
 func Read(limit int) ([]Session, error) {
 	path, err := LogPath()
 	if err != nil {
 		return nil, err
 	}
 	// #nosec G304 -- same fixed-path rationale as Write().
-	data, err := os.ReadFile(path)
+	f, err := os.Open(path)
 	if os.IsNotExist(err) {
 		return nil, nil
 	}
 	if err != nil {
 		return nil, err
 	}
+	defer f.Close()
 
 	var all []Session
-	for _, line := range splitLines(data) {
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Bytes()
 		if len(line) == 0 {
 			continue
 		}
@@ -104,26 +109,9 @@ func Read(limit int) ([]Session, error) {
 			continue
 		}
 		all = append(all, s)
-	}
-	if limit > 0 && len(all) > limit {
-		all = all[len(all)-limit:]
-	}
-	return all, nil
-}
-
-// splitLines is a small helper that avoids pulling in bufio.Scanner just to
-// split on '\n'. Each returned slice references the original buffer.
-func splitLines(b []byte) [][]byte {
-	var out [][]byte
-	start := 0
-	for i, c := range b {
-		if c == '\n' {
-			out = append(out, b[start:i])
-			start = i + 1
+		if limit > 0 && len(all) > limit {
+			all = all[1:]
 		}
 	}
-	if start < len(b) {
-		out = append(out, b[start:])
-	}
-	return out
+	return all, scanner.Err()
 }

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -57,6 +57,8 @@ func Write(s Session) error {
 
 	// O_APPEND on POSIX is atomic for writes <= PIPE_BUF; one JSON line is
 	// well under that, so concurrent `rapg run` invocations don't interleave.
+	// #nosec G304 -- path is fixed at ~/.rapg/sessions.jsonl, derived from
+	// os.UserHomeDir(); not influenced by external input.
 	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
 	if err != nil {
 		return err
@@ -81,6 +83,7 @@ func Read(limit int) ([]Session, error) {
 	if err != nil {
 		return nil, err
 	}
+	// #nosec G304 -- same fixed-path rationale as Write().
 	data, err := os.ReadFile(path)
 	if os.IsNotExist(err) {
 		return nil, nil

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -92,7 +92,9 @@ func TestRead_skipsMalformedLines(t *testing.T) {
 	if _, err := f.Write([]byte("not json\n")); err != nil {
 		t.Fatal(err)
 	}
-	f.Close()
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
 
 	if err := Write(Session{Command: "ok-2"}); err != nil {
 		t.Fatal(err)

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -1,0 +1,111 @@
+package audit
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func TestWriteAndRead_roundTrip(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	want := Session{
+		Command:   "claude",
+		Args:      []string{"code", "--print"},
+		Namespace: "myapp",
+		EnvKeys:   []string{"DB_URL", "ANTHROPIC_API_KEY"},
+		ExitCode:  0,
+		PID:       42,
+		Cwd:       "/home/me/code/myapp",
+	}
+	if err := Write(want); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	got, err := Read(0)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("Read returned %d entries, want 1", len(got))
+	}
+	g := got[0]
+	if g.Command != want.Command || g.Namespace != want.Namespace || g.ExitCode != want.ExitCode {
+		t.Errorf("scalar fields mismatch: %#v", g)
+	}
+	if len(g.EnvKeys) != 2 || g.EnvKeys[0] != "ANTHROPIC_API_KEY" || g.EnvKeys[1] != "DB_URL" {
+		t.Errorf("EnvKeys not sorted on write: %#v", g.EnvKeys)
+	}
+	if g.Timestamp.IsZero() {
+		t.Error("Write should default Timestamp to now")
+	}
+}
+
+func TestRead_limitTakesTail(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	for i := range 5 {
+		if err := Write(Session{Command: "echo", ExitCode: i, Timestamp: time.Now().UTC()}); err != nil {
+			t.Fatalf("Write %d: %v", i, err)
+		}
+	}
+
+	got, err := Read(2)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("Read(2) returned %d, want 2", len(got))
+	}
+	// Tail of 5 entries with ExitCode 0..4 → last two are 3, 4.
+	if got[0].ExitCode != 3 || got[1].ExitCode != 4 {
+		t.Errorf("Read(2) returned wrong tail: %v, %v", got[0].ExitCode, got[1].ExitCode)
+	}
+}
+
+func TestRead_missingFile(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	got, err := Read(0)
+	if err != nil {
+		t.Fatalf("Read on missing file should not error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("Read on missing file should return nil, got %v", got)
+	}
+}
+
+func TestRead_skipsMalformedLines(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	if err := Write(Session{Command: "ok-1"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Append a malformed line directly (writers other than us could in
+	// theory corrupt the file).
+	path, _ := LogPath()
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write([]byte("not json\n")); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	if err := Write(Session{Command: "ok-2"}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := Read(0)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 valid entries, got %d", len(got))
+	}
+	if got[0].Command != "ok-1" || got[1].Command != "ok-2" {
+		t.Errorf("malformed line not skipped: %#v", got)
+	}
+}

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -1,0 +1,62 @@
+// Package redact masks vault values appearing in arbitrary text — typically
+// agent transcripts (Claude Code, Cursor, Aider) before sharing them in bug
+// reports or pasting into chat. The package itself is pure: it takes a
+// list of (value, label) pairs and a haystack, and returns the haystack with
+// every value occurrence replaced by '[REDACTED:<label>]'.
+//
+// Two safety rules:
+//
+//   - Values shorter than MinLength characters are skipped. A vault entry
+//     with password "test" would otherwise mask every "test" in the text.
+//   - Longer values are processed before shorter ones, so a value contained
+//     inside another value doesn't get partially shadowed.
+package redact
+
+import (
+	"sort"
+	"strings"
+)
+
+// MinLength is the shortest secret value Redact will substitute. Anything
+// shorter is treated as too generic to be a unique secret.
+const MinLength = 8
+
+// Secret is one (value, label) pair fed to Redact.
+type Secret struct {
+	// Value is the literal string to search for in the haystack.
+	Value string
+	// Label is what the mask reads — typically an env-key name like
+	// "ANTHROPIC_API_KEY" or a service identifier. Goes into
+	// "[REDACTED:<label>]".
+	Label string
+}
+
+// Redact returns input with every occurrence of each Secret.Value replaced
+// by "[REDACTED:<Label>]". Values shorter than MinLength are skipped.
+// Returns the count of distinct values that actually matched.
+func Redact(input string, secrets []Secret) (string, int) {
+	// Sort by descending length so longer values are masked before any
+	// shorter values they might contain. (Example: vault has both
+	// "sk-ant-abc12345" and "abc12345" — without this ordering the second
+	// pass would reach into the already-masked first match.)
+	sorted := make([]Secret, 0, len(secrets))
+	for _, s := range secrets {
+		if len(s.Value) >= MinLength {
+			sorted = append(sorted, s)
+		}
+	}
+	sort.SliceStable(sorted, func(i, j int) bool {
+		return len(sorted[i].Value) > len(sorted[j].Value)
+	})
+
+	out := input
+	matched := 0
+	for _, s := range sorted {
+		if !strings.Contains(out, s.Value) {
+			continue
+		}
+		out = strings.ReplaceAll(out, s.Value, "[REDACTED:"+s.Label+"]")
+		matched++
+	}
+	return out, matched
+}

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -35,15 +35,23 @@ type Secret struct {
 // by "[REDACTED:<Label>]". Values shorter than MinLength are skipped.
 // Returns the count of distinct values that actually matched.
 func Redact(input string, secrets []Secret) (string, int) {
-	// Sort by descending length so longer values are masked before any
-	// shorter values they might contain. (Example: vault has both
-	// "sk-ant-abc12345" and "abc12345" — without this ordering the second
-	// pass would reach into the already-masked first match.)
+	// Filter + de-dup by Value (vaults often have the same password under
+	// multiple service names; processing it twice is wasted work). First
+	// label wins. Then sort by descending length so longer values are
+	// masked before any shorter values they might contain. (Example: vault
+	// has both "sk-ant-abc12345" and "abc12345" — without this ordering the
+	// second pass would reach into the already-masked first match.)
 	sorted := make([]Secret, 0, len(secrets))
+	seen := make(map[string]struct{}, len(secrets))
 	for _, s := range secrets {
-		if len(s.Value) >= MinLength {
-			sorted = append(sorted, s)
+		if len(s.Value) < MinLength {
+			continue
 		}
+		if _, dup := seen[s.Value]; dup {
+			continue
+		}
+		seen[s.Value] = struct{}{}
+		sorted = append(sorted, s)
 	}
 	sort.SliceStable(sorted, func(i, j int) bool {
 		return len(sorted[i].Value) > len(sorted[j].Value)

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -1,0 +1,74 @@
+package redact
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRedact_basic(t *testing.T) {
+	in := "DB url is postgres://user:supersecret123@localhost/db, and the API key is sk-ant-abc12345xyz."
+	got, n := Redact(in, []Secret{
+		{Value: "supersecret123", Label: "DB_URL_PASSWORD"},
+		{Value: "sk-ant-abc12345xyz", Label: "ANTHROPIC_API_KEY"},
+	})
+	if n != 2 {
+		t.Errorf("matched count = %d, want 2", n)
+	}
+	if strings.Contains(got, "supersecret123") || strings.Contains(got, "sk-ant-abc12345xyz") {
+		t.Errorf("plaintext leaked: %q", got)
+	}
+	if !strings.Contains(got, "[REDACTED:DB_URL_PASSWORD]") || !strings.Contains(got, "[REDACTED:ANTHROPIC_API_KEY]") {
+		t.Errorf("masks missing: %q", got)
+	}
+}
+
+func TestRedact_skipsShortValues(t *testing.T) {
+	in := "the test passed; testing was fine"
+	got, n := Redact(in, []Secret{{Value: "test", Label: "TOO_SHORT"}})
+	if n != 0 {
+		t.Errorf("matched count = %d, want 0", n)
+	}
+	if got != in {
+		t.Errorf("short value should not have been substituted: %q", got)
+	}
+}
+
+func TestRedact_longerValueProcessedFirst(t *testing.T) {
+	// Both values present; the longer one contains the shorter as a
+	// suffix. Without longest-first ordering, masking "abcd1234" first
+	// would still leave "wxyzabcd1234" reachable, then masking that
+	// longer string would partially overlap. Ordering avoids that.
+	in := "longer: wxyzabcd1234; shorter: abcd1234"
+	got, n := Redact(in, []Secret{
+		{Value: "abcd1234", Label: "SHORT"},
+		{Value: "wxyzabcd1234", Label: "LONG"},
+	})
+	if n != 2 {
+		t.Errorf("matched count = %d, want 2", n)
+	}
+	if strings.Contains(got, "abcd1234") {
+		t.Errorf("plaintext leaked: %q", got)
+	}
+	if !strings.Contains(got, "[REDACTED:LONG]") || !strings.Contains(got, "[REDACTED:SHORT]") {
+		t.Errorf("expected both masks: %q", got)
+	}
+}
+
+func TestRedact_noMatches(t *testing.T) {
+	in := "nothing to redact here"
+	got, n := Redact(in, []Secret{{Value: "absent_value_long", Label: "X"}})
+	if n != 0 {
+		t.Errorf("matched count = %d, want 0", n)
+	}
+	if got != in {
+		t.Errorf("no-match should leave input unchanged")
+	}
+}
+
+func TestRedact_emptySecretsList(t *testing.T) {
+	in := "anything goes"
+	got, n := Redact(in, nil)
+	if n != 0 || got != in {
+		t.Errorf("empty secrets should return input unchanged")
+	}
+}

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -72,3 +72,25 @@ func TestRedact_emptySecretsList(t *testing.T) {
 		t.Errorf("empty secrets should return input unchanged")
 	}
 }
+
+// TestRedact_dedupesByValue confirms that the same Value appearing in
+// multiple Secret entries is processed once (first label wins).
+func TestRedact_dedupesByValue(t *testing.T) {
+	in := "the secret is sharedpassword123 and again sharedpassword123"
+	got, n := Redact(in, []Secret{
+		{Value: "sharedpassword123", Label: "FIRST"},
+		{Value: "sharedpassword123", Label: "SECOND"},
+	})
+	if n != 1 {
+		t.Errorf("matched count = %d, want 1 (dedup expected)", n)
+	}
+	if strings.Contains(got, "sharedpassword123") {
+		t.Errorf("plaintext leaked: %q", got)
+	}
+	if strings.Contains(got, "[REDACTED:SECOND]") {
+		t.Errorf("second-label mask should be suppressed by dedup; got %q", got)
+	}
+	if !strings.Contains(got, "[REDACTED:FIRST]") {
+		t.Errorf("first-label mask missing: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

PR-C of 3 for v4.0 — closes the agent-leakage narrative loop.

Two complementary capabilities:

1. **`rapg redact <file|->`** — pulls vault values, scans the input, replaces every match with `[REDACTED:<env_key>]`. Use this on agent transcripts before sharing them in a bug report or pasting into chat.
2. **`rapg session log`** — reads `~/.rapg/sessions.jsonl`, an append-only metadata trail recording which command got which env keys (NOT values) and when. Populated automatically by every `rapg run --` invocation.

```bash
# Before sharing a Claude Code transcript:
rapg redact ~/.claude/transcripts/today.jsonl > redacted.jsonl

# Audit recent runs:
rapg session log
# 2026-05-05 14:30:12  [myapp]  claude code --print  exit=0  keys: ANTHROPIC_API_KEY,DB_URL
# 2026-05-05 14:32:05  [-]       npm run dev          exit=0  keys: -
```

### What changed (commit by commit)

1. `32d8c3e` — **`internal/audit`**: JSONL append-only writer at `~/.rapg/sessions.jsonl` (mode 0600). `Write(Session)`, `Read(limit)`. Tolerates malformed lines on read. POSIX `O_APPEND` keeps concurrent writes atomic.
2. `d6e05a1` — **`cmd`**: `rapg run` calls `audit.Write` after the child exits. Failure non-fatal (warn, never block).
3. `5b24013` — **`cmd`**: parent `rapg session` + child `log` subcommand. Tab-aligned output, `--limit` flag, future-proof for `session clear/export/...`.
4. `360355e` — **`internal/redact`**: pure value-masking function. Two safety rules baked in: skip values < 8 chars, process longer values first.
5. `302dbc1` — **`cmd`**: `rapg redact <file|->` subcommand. Vault-wide scope (no `.rapg.toml` filtering — maximum coverage when auditing a transcript).
6. `57de1b1` — **`docs`**: README adds Transcript hygiene + Audit log sections, expands Subcommands table, drops shipped items from Roadmap. Also suppresses 3 gosec G304 false positives (fixed `~/.rapg/` path + explicit user CLI input — the user IS the trust boundary in a CLI).

### Design notes

- **Why JSONL, not SQLite for the session log**: easier to grep, doesn't bloat the encrypted vault, easy to wipe (`rm`). The vault DB stays exclusively for secrets.
- **Why redact ignores `.rapg.toml`**: when scrubbing a transcript, you want to catch any vault leak regardless of project. Project scoping is a `run`-time concept; redact is a forensic pass.
- **MinLength = 8**: empirical — anything shorter is too likely to be a substring of normal text and produce noise.

## Test plan

- [x] `go vet`, `staticcheck`, `gosec` (0 issues), `govulncheck` (0 vulns) all clean
- [x] `go test -race ./...` all green — new tests in `internal/audit` (round-trip / tail-limit / missing-file / malformed-line) and `internal/redact` (basic / short-skip / longest-first / no-match / empty-list)
- [x] `npx markdownlint-cli2 README.md` 0 errors
- [x] Manual smoke: `rapg session log` empty case, then with hand-seeded `sessions.jsonl`, prints aligned table correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `rapg redact` command to mask sensitive information from transcripts and output.
  * Added `rapg session log` command to view audit logs of recent runs with configurable limit.
  * Execution runs now automatically logged for audit and compliance tracking.
  * Added documentation for new subcommands (`rapg project`, `rapg hook`, `rapg nuke`).

* **Documentation**
  * Updated README with examples and descriptions for transcript hygiene and audit logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->