### PR TITLE
docs: position rapg against agent-secret trends

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,17 @@ A minimal verification script lives at `examples/main.py`:
 rapg run -- python examples/main.py
 ```
 
+### Wrapping MCP servers
+
+An MCP server is just another child process that needs credentials — and 2026 security guidance flags MCP servers as a dangerous single point of credential aggregation. Wrap one with `rapg run` so its token comes from the vault instead of a `.env` file on disk:
+
+```bash
+# any MCP server that reads its token from the environment
+rapg run -- npx -y @modelcontextprotocol/server-github
+```
+
+The server reads its credential (e.g. a GitHub PAT) from the environment you tagged with an `Env Key`; the value never lands in a config file, the shell history, or — if you pair this with `inherit_global = false` — any other project's context.
+
 ## TUI keys
 
 | Key | Action |
@@ -181,6 +192,11 @@ Next on the agent-leakage track:
 | Encryption | AES-256-GCM (NIST SP 800-38D) with a 12-byte random nonce per record |
 | Memory protection | Master key held in a `memguard` LockedBuffer and zeroed on exit |
 | At-rest layout | Single SQLite file at `~/.rapg/rapg.db`, directory mode `0700` |
+| Prompt-injection blast radius | Secrets go into the child's environment, never the prompt or context window; `rapg redact` scrubs vault values from transcripts before you share them |
+
+## Scope
+
+rapg secures the **secret boundary on your local dev machine** — keeping real keys off disk and out of agent transcripts. It is deliberately not a production identity platform: per-agent non-human identities, workload identity federation, and automated provider-side rotation belong in your cloud IAM or a server-side vault (HashiCorp Vault, AWS Secrets Manager). rapg is the local-first complement to those, not a replacement.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ An MCP server is just another child process that needs credentials — and 2026 
 rapg run -- npx -y @modelcontextprotocol/server-github
 ```
 
-The server reads its credential (e.g. a GitHub PAT) from the environment you tagged with an `Env Key`; the value never lands in a config file, the shell history, or — if you pair this with `inherit_global = false` — any other project's context.
+The server reads its credential (e.g. a GitHub PAT) from the environment you tagged with an `Env Key`; the value never lands in a config file, the shell history, or — since `inherit_global` defaults to `false` — any other project's context.
 
 ## TUI keys
 

--- a/README.md
+++ b/README.md
@@ -54,14 +54,14 @@ rapg run -- python examples/main.py
 
 ### Wrapping MCP servers
 
-An MCP server is just another child process that needs credentials — and 2026 security guidance flags MCP servers as a dangerous single point of credential aggregation. Wrap one with `rapg run` so its token comes from the vault instead of a `.env` file on disk:
+An MCP server is just another child process that needs credentials, and 2026 security guidance flags MCP servers as a dangerous single point of credential aggregation. Wrap one with `rapg run` so its token comes from the vault instead of a `.env` file on disk:
 
 ```bash
 # any MCP server that reads its token from the environment
 rapg run -- npx -y @modelcontextprotocol/server-github
 ```
 
-The server reads its credential (e.g. a GitHub PAT) from the environment you tagged with an `Env Key`; the value never lands in a config file, the shell history, or — since `inherit_global` defaults to `false` — any other project's context.
+The server reads its credential (e.g. a GitHub PAT) from the environment you tagged with an `Env Key`; the value never lands in a config file, the shell history, or (since `inherit_global` defaults to `false`) any other project's context.
 
 ## TUI keys
 
@@ -196,7 +196,7 @@ Next on the agent-leakage track:
 
 ## Scope
 
-rapg secures the **secret boundary on your local dev machine** — keeping real keys off disk and out of agent transcripts. It is deliberately not a production identity platform: per-agent non-human identities, workload identity federation, and automated provider-side rotation belong in your cloud IAM or a server-side vault (HashiCorp Vault, AWS Secrets Manager). rapg is the local-first complement to those, not a replacement.
+rapg secures the **secret boundary on your local dev machine**: keeping real keys off disk and out of agent transcripts. It is deliberately not a production identity platform: per-agent non-human identities, workload identity federation, and automated provider-side rotation belong in your cloud IAM or a server-side vault (HashiCorp Vault, AWS Secrets Manager). rapg is the local-first complement to those, not a replacement.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ An MCP server is just another child process that needs credentials, and 2026 sec
 rapg run -- npx -y @modelcontextprotocol/server-github
 ```
 
-The server reads its credential (e.g. a GitHub PAT) from the environment you tagged with an `Env Key`; the value never lands in a config file, the shell history, or (since `inherit_global` defaults to `false`) any other project's context.
+The server reads its credential (e.g. a GitHub PAT) from the environment variable named by the entry's `Env Key`; the value never lands in a config file, the shell history, or (since `inherit_global` defaults to `false`) any other project's context.
 
 ## TUI keys
 
@@ -196,7 +196,7 @@ Next on the agent-leakage track:
 
 ## Scope
 
-rapg secures the **secret boundary on your local dev machine**: keeping real keys off disk and out of agent transcripts. It is deliberately not a production identity platform: per-agent non-human identities, workload identity federation, and automated provider-side rotation belong in your cloud IAM or a server-side vault (HashiCorp Vault, AWS Secrets Manager). rapg is the local-first complement to those, not a replacement.
+rapg secures the **secret boundary on your local dev machine**. It keeps real keys off disk and out of agent transcripts. It is deliberately not a production identity platform: per-agent non-human identities, workload identity federation, and automated provider-side rotation belong in your cloud IAM or a server-side vault (HashiCorp Vault, AWS Secrets Manager). rapg is the local-first complement to those, not a replacement.
 
 ## License
 


### PR DESCRIPTION
Positions rapg against the 2026 agent-secret landscape (researched from GitGuardian's secrets-sprawl report, NSA/SentinelOne MCP guidance, and current vault/proxy practice). Docs-only — no behavior change.

## Changes

- **MCP-server wrapping example.** `rapg run -- <mcp server>` keeps an MCP server's token in the vault instead of a `.env` on disk. 2026 guidance repeatedly flags MCP servers as a single point of credential aggregation, so this is a natural fit for rapg's threat model.
- **Prompt-injection row in the Security table.** Makes explicit that secrets go into the child's environment, never the prompt/context window, and that `rapg redact` scrubs transcripts before sharing.
- **New Scope section.** Clarifies rapg is the local-machine secret boundary — not a production per-agent non-human-identity / workload-federation platform. Sets expectations against tools like HashiCorp Vault / AWS Secrets Manager.

## Verification

- `markdownlint-cli2` clean against the global config.
