### PR TITLE
feat: surface secret rotation freshness in the TUI

### DIFF
--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -26,7 +26,7 @@ type SecretData struct {
 	Url      string `json:"url,omitempty"`
 	EnvKey   string `json:"env_key,omitempty"`
 	// RotatedAt is when the password was last set or rotated. Zero for
-	// entries created before rotation tracking existed — callers treat that
+	// entries created before rotation tracking existed, so callers treat that
 	// as "unknown", not "fresh".
 	RotatedAt time.Time `json:"rotated_at,omitzero"`
 }
@@ -42,7 +42,7 @@ func (d SecretData) RotationAge(now time.Time) (age time.Duration, ok bool) {
 }
 
 // IsStale reports whether the secret is older than StaleAfter. Entries with
-// an unknown rotation time are never reported stale — we don't nag about
+// an unknown rotation time are never reported stale, so we don't nag about
 // data we can't date.
 func (d SecretData) IsStale(now time.Time) bool {
 	age, ok := d.RotationAge(now)

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -5,11 +5,18 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
 )
+
+// StaleAfter is how long a secret may go without rotation before rapg
+// surfaces a freshness reminder. Static dev credentials don't auto-rotate
+// (2026 guidance pushes short-lived/rotated creds), so this is a nudge, not
+// enforcement.
+const StaleAfter = 90 * 24 * time.Hour
 
 // SecretData is the structure that gets serialized and encrypted.
 type SecretData struct {
@@ -18,6 +25,28 @@ type SecretData struct {
 	Notes    string `json:"notes,omitempty"`
 	Url      string `json:"url,omitempty"`
 	EnvKey   string `json:"env_key,omitempty"`
+	// RotatedAt is when the password was last set or rotated. Zero for
+	// entries created before rotation tracking existed — callers treat that
+	// as "unknown", not "fresh".
+	RotatedAt time.Time `json:"rotated_at,omitzero"`
+}
+
+// RotationAge reports how long ago the secret was last set/rotated relative
+// to now. ok is false when RotatedAt is zero (legacy entries predating
+// rotation tracking), letting callers distinguish "fresh" from "unknown".
+func (d SecretData) RotationAge(now time.Time) (age time.Duration, ok bool) {
+	if d.RotatedAt.IsZero() {
+		return 0, false
+	}
+	return now.Sub(d.RotatedAt), true
+}
+
+// IsStale reports whether the secret is older than StaleAfter. Entries with
+// an unknown rotation time are never reported stale — we don't nag about
+// data we can't date.
+func (d SecretData) IsStale(now time.Time) bool {
+	age, ok := d.RotationAge(now)
+	return ok && age > StaleAfter
 }
 
 // PasswordEntry is one row in the vault. Namespace scopes the entry to a

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -1,8 +1,70 @@
 package storage
 
 import (
+	"encoding/json"
 	"testing"
+	"time"
 )
+
+func TestRotationAge(t *testing.T) {
+	now := time.Date(2026, 6, 14, 0, 0, 0, 0, time.UTC)
+
+	// Unknown (zero) rotation time: ok=false, never stale.
+	var unknown SecretData
+	if _, ok := unknown.RotationAge(now); ok {
+		t.Error("zero RotatedAt should report ok=false")
+	}
+	if unknown.IsStale(now) {
+		t.Error("untracked entry must never be reported stale")
+	}
+
+	// Fresh: one day old.
+	fresh := SecretData{RotatedAt: now.Add(-24 * time.Hour)}
+	age, ok := fresh.RotationAge(now)
+	if !ok || age != 24*time.Hour {
+		t.Errorf("RotationAge = %v, %v; want 24h, true", age, ok)
+	}
+	if fresh.IsStale(now) {
+		t.Error("1-day-old entry should not be stale")
+	}
+
+	// Stale: older than StaleAfter.
+	old := SecretData{RotatedAt: now.Add(-(StaleAfter + time.Hour))}
+	if !old.IsStale(now) {
+		t.Error("entry older than StaleAfter should be stale")
+	}
+
+	// Boundary: exactly StaleAfter old is not yet stale (strict >).
+	edge := SecretData{RotatedAt: now.Add(-StaleAfter)}
+	if edge.IsStale(now) {
+		t.Error("entry exactly StaleAfter old should not yet be stale")
+	}
+}
+
+func TestSecretDataRotatedAtRoundTrip(t *testing.T) {
+	ts := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	b, err := json.Marshal(SecretData{Password: "p", RotatedAt: ts})
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	var out SecretData
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if !out.RotatedAt.Equal(ts) {
+		t.Errorf("RotatedAt round-trip = %v, want %v", out.RotatedAt, ts)
+	}
+
+	// Legacy payloads without the field must decode to the zero time, which
+	// RotationAge treats as "unknown".
+	var legacy SecretData
+	if err := json.Unmarshal([]byte(`{"password":"p"}`), &legacy); err != nil {
+		t.Fatalf("legacy unmarshal failed: %v", err)
+	}
+	if !legacy.RotatedAt.IsZero() {
+		t.Errorf("missing rotated_at should be zero time, got %v", legacy.RotatedAt)
+	}
+}
 
 // setupTestDB creates a temporary directory, sets HOME to it, and initializes the DB.
 // It returns a cleanup function that should be deferred.

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -380,14 +380,14 @@ func (m *Model) updateDetailView() {
 		b.WriteString(labelStyle.Render("Env Key:  ") + valueStyle.Render(ss.EnvKey) + "\n")
 	}
 
-	// Rotation freshness — static dev creds don't auto-rotate, so nudge when
+	// Rotation freshness: static dev creds don't auto-rotate, so nudge when
 	// one is older than storage.StaleAfter. Untracked (legacy) entries show
 	// nothing rather than a misleading "fresh". One time.Now() so the age and
 	// the stale verdict stay consistent within this render.
 	now := time.Now()
 	if age, ok := ss.RotationAge(now); ok {
 		if age < 0 {
-			// Clock skew or a future timestamp — don't render "-3d ago".
+			// Clock skew or a future timestamp; don't render "-3d ago".
 			age = 0
 		}
 		days := int(age.Hours()) / 24

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -386,6 +386,10 @@ func (m *Model) updateDetailView() {
 	// the stale verdict stay consistent within this render.
 	now := time.Now()
 	if age, ok := ss.RotationAge(now); ok {
+		if age < 0 {
+			// Clock skew or a future timestamp — don't render "-3d ago".
+			age = 0
+		}
 		days := int(age.Hours()) / 24
 		when := fmt.Sprintf("%dd ago", days)
 		if days == 0 {

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -380,6 +380,22 @@ func (m *Model) updateDetailView() {
 		b.WriteString(labelStyle.Render("Env Key:  ") + valueStyle.Render(ss.EnvKey) + "\n")
 	}
 
+	// Rotation freshness — static dev creds don't auto-rotate, so nudge when
+	// one is older than storage.StaleAfter. Untracked (legacy) entries show
+	// nothing rather than a misleading "fresh".
+	if age, ok := ss.RotationAge(time.Now()); ok {
+		days := int(age.Hours()) / 24
+		when := fmt.Sprintf("%dd ago", days)
+		if days == 0 {
+			when = "today"
+		}
+		if ss.IsStale(time.Now()) {
+			b.WriteString(labelStyle.Render("Rotated:  ") + errorStyle.Render(when+"  ⚠ consider rotating") + "\n")
+		} else {
+			b.WriteString(labelStyle.Render("Rotated:  ") + valueStyle.Render(when) + "\n")
+		}
+	}
+
 	// TOTP
 	if ss.TOTP != "" {
 		code, err := totp.GenerateCode(ss.TOTP, time.Now())
@@ -421,10 +437,11 @@ func (m *Model) submitAdd() tea.Cmd {
 	}
 
 	data := storage.SecretData{
-		Password: pass,
-		TOTP:     totpSecret,
-		EnvKey:   envKey,
-		Notes:    notes,
+		Password:  pass,
+		TOTP:      totpSecret,
+		EnvKey:    envKey,
+		Notes:     notes,
+		RotatedAt: time.Now(),
 	}
 
 	if err := core.AddEntry(namespace, service, username, data); err != nil {

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -390,7 +390,7 @@ func (m *Model) updateDetailView() {
 			// Clock skew or a future timestamp; don't render "-3d ago".
 			age = 0
 		}
-		days := int(age.Hours()) / 24
+		days := int(age / (24 * time.Hour))
 		when := fmt.Sprintf("%dd ago", days)
 		if days == 0 {
 			when = "today"

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -382,14 +382,16 @@ func (m *Model) updateDetailView() {
 
 	// Rotation freshness — static dev creds don't auto-rotate, so nudge when
 	// one is older than storage.StaleAfter. Untracked (legacy) entries show
-	// nothing rather than a misleading "fresh".
-	if age, ok := ss.RotationAge(time.Now()); ok {
+	// nothing rather than a misleading "fresh". One time.Now() so the age and
+	// the stale verdict stay consistent within this render.
+	now := time.Now()
+	if age, ok := ss.RotationAge(now); ok {
 		days := int(age.Hours()) / 24
 		when := fmt.Sprintf("%dd ago", days)
 		if days == 0 {
 			when = "today"
 		}
-		if ss.IsStale(time.Now()) {
+		if ss.IsStale(now) {
 			b.WriteString(labelStyle.Render("Rotated:  ") + errorStyle.Render(when+"  ⚠ consider rotating") + "\n")
 		} else {
 			b.WriteString(labelStyle.Render("Rotated:  ") + valueStyle.Render(when) + "\n")
@@ -441,7 +443,7 @@ func (m *Model) submitAdd() tea.Cmd {
 		TOTP:      totpSecret,
 		EnvKey:    envKey,
 		Notes:     notes,
-		RotatedAt: time.Now(),
+		RotatedAt: time.Now().UTC(),
 	}
 
 	if err := core.AddEntry(namespace, service, username, data); err != nil {


### PR DESCRIPTION
Adds a freshness nudge for vault secrets. 2026 best-practice guidance pushes short-lived / rotated credentials, but rapg holds static dev secrets — so the next best thing is to make staleness *visible* without changing the storage model or adding provider integrations.

## Changes

- `SecretData.RotatedAt` (JSON `omitzero`), set when a new entry is added in the TUI. Entries created before this field existed decode to the zero time and are treated as **unknown**, never falsely reported as "fresh".
- Pure helpers `RotationAge(now)` / `IsStale(now)` and a `StaleAfter = 90d` threshold on the storage type, so the policy is unit-testable and UI-independent.
- Detail view shows `Rotated: Nd ago`, switching to a `⚠ consider rotating` warning once a secret passes the threshold.

## Notes

- No migration needed — the field is additive inside the already-encrypted `SecretData` blob; legacy rows just lack it.
- Threshold is a constant for now; making it configurable can come later if anyone asks.

## Verification

- `go test ./...` all pass (new boundary + JSON round-trip + legacy-payload tests in `storage_test.go`)
- `go vet`, `staticcheck`, `gosec` (0 issues), `gofmt -l` all clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vault “Details” now shows secret rotation freshness, including “today” or “Nd ago” formatting.
  * Secrets with rotation data older than 90 days are flagged as stale with a warning.
  * Newly added secrets automatically record their rotation timestamp so freshness can display immediately.
* **Tests**
  * Added coverage for rotation-age/staleness logic (including boundary behavior) and for round-trip JSON handling of the rotation timestamp.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->