### PR TITLE
feat(proxy): localhost short-lived-token gateway core

### DIFF
--- a/internal/proxy/provider.go
+++ b/internal/proxy/provider.go
@@ -1,0 +1,87 @@
+// Package proxy implements a localhost-only gateway that holds a real
+// provider API key and hands AI agents a short-lived, loopback-bound proxy
+// token instead. The agent talks to the gateway with the token; the gateway
+// swaps in the real key and forwards to the upstream provider. The real key
+// never enters the agent's environment, so a prompt-injected agent that reads
+// its own env leaks only a token that dies with the process and is useless
+// off-machine.
+//
+// See docs/proxy-design.md for the threat model and rationale.
+package proxy
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// Provider isolates the per-vendor differences: where to forward, how the
+// real key is carried on the outbound request, how the agent's inbound proxy
+// token is read, and which env vars point an agent at the gateway.
+type Provider interface {
+	// Name is the --provider value, e.g. "anthropic".
+	Name() string
+	// UpstreamBaseURL is where verified requests are forwarded.
+	UpstreamBaseURL() string
+	// InboundToken extracts the proxy token the agent sent on the request,
+	// or "" if absent.
+	InboundToken(r *http.Request) string
+	// SetRealAuth puts the real key on the outbound request in the form this
+	// provider expects, and removes any proxy-token auth headers.
+	SetRealAuth(r *http.Request, realKey string)
+	// ChildEnv returns the env vars to inject so an agent talks to the
+	// gateway instead of the provider directly.
+	ChildEnv(listenURL, proxyToken string) map[string]string
+}
+
+// Lookup returns the Provider for a --provider value, or an error naming the
+// supported set.
+func Lookup(name string) (Provider, error) {
+	switch name {
+	case "anthropic":
+		return anthropic{}, nil
+	default:
+		return nil, fmt.Errorf("unsupported provider %q (supported: anthropic)", name)
+	}
+}
+
+// bearer pulls the token out of an "Authorization: Bearer <token>" header,
+// returning "" when the header is missing or not a bearer scheme.
+func bearer(r *http.Request) string {
+	const prefix = "Bearer "
+	v := r.Header.Get("Authorization")
+	if len(v) > len(prefix) && strings.EqualFold(v[:len(prefix)], prefix) {
+		return v[len(prefix):]
+	}
+	return ""
+}
+
+// anthropic targets api.anthropic.com. Claude Code with ANTHROPIC_AUTH_TOKEN
+// sends the token as "Authorization: Bearer <token>"; with ANTHROPIC_API_KEY
+// it sends "x-api-key: <token>". We accept either so both env conventions
+// work. The real key is sent upstream as x-api-key.
+type anthropic struct{}
+
+func (anthropic) Name() string            { return "anthropic" }
+func (anthropic) UpstreamBaseURL() string { return "https://api.anthropic.com" }
+
+func (anthropic) InboundToken(r *http.Request) string {
+	if t := bearer(r); t != "" {
+		return t
+	}
+	return r.Header.Get("x-api-key")
+}
+
+func (anthropic) SetRealAuth(r *http.Request, realKey string) {
+	// Strip whatever proxy-token auth the agent sent, then set the real key
+	// the way Anthropic expects it.
+	r.Header.Del("Authorization")
+	r.Header.Set("x-api-key", realKey)
+}
+
+func (anthropic) ChildEnv(listenURL, proxyToken string) map[string]string {
+	return map[string]string{
+		"ANTHROPIC_BASE_URL":   listenURL,
+		"ANTHROPIC_AUTH_TOKEN": proxyToken,
+	}
+}

--- a/internal/proxy/provider.go
+++ b/internal/proxy/provider.go
@@ -83,5 +83,10 @@ func (anthropic) ChildEnv(listenURL, proxyToken string) map[string]string {
 	return map[string]string{
 		"ANTHROPIC_BASE_URL":   listenURL,
 		"ANTHROPIC_AUTH_TOKEN": proxyToken,
+		// Also set ANTHROPIC_API_KEY so the official SDKs (Python, TS, Go),
+		// which ignore ANTHROPIC_AUTH_TOKEN, still authenticate. They send it
+		// as x-api-key, which InboundToken accepts. Since the proxy strips the
+		// real key from the child env, this is the token, not the real key.
+		"ANTHROPIC_API_KEY": proxyToken,
 	}
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -67,14 +67,23 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// 1. Verify the proxy token in constant time. A mismatch (or an absent
 	//    token) is rejected before we touch the real key or the upstream.
 	got := g.provider.InboundToken(r)
-	if subtle.ConstantTimeCompare([]byte(got), []byte(g.token)) != 1 {
+	// Length check first: the token is a fixed, public-length string, so
+	// rejecting a wrong length leaks nothing and avoids allocating a byte
+	// slice for an arbitrarily large header. The compare stays constant-time
+	// for equal lengths.
+	if len(got) != len(g.token) || subtle.ConstantTimeCompare([]byte(got), []byte(g.token)) != 1 {
 		http.Error(w, "invalid or missing proxy token", http.StatusUnauthorized)
 		return
 	}
 
-	// 2. Build the outbound request against the upstream base.
+	// 2. Build the outbound request against the upstream base. Preserve
+	//    RawPath so escaped path segments (e.g. %2F) survive — r.URL.Path is
+	//    unescaped, only RawPath carries the original encoding.
 	out := *g.upstream
 	out.Path = singleJoiningSlash(g.upstream.Path, r.URL.Path)
+	if r.URL.RawPath != "" {
+		out.RawPath = singleJoiningSlash(g.upstream.RawPath, r.URL.RawPath)
+	}
 	out.RawQuery = r.URL.RawQuery
 
 	req, err := http.NewRequestWithContext(r.Context(), r.Method, out.String(), r.Body)

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -46,7 +46,15 @@ func New(p Provider, realKey, token string) (*Gateway, error) {
 		realKey:  realKey,
 		token:    token,
 		upstream: base,
-		client:   &http.Client{},
+		client: &http.Client{
+			// Never follow redirects. Go copies custom headers (like the
+			// real x-api-key) across cross-domain redirects, so an upstream
+			// or open-redirect to another host could leak the real key.
+			// Return the 3xx to the agent instead.
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
 	}, nil
 }
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1,0 +1,156 @@
+package proxy
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// NewToken mints a random 32-byte proxy token, hex-encoded. It is minted per
+// invocation, held only in memory, and never written to disk.
+func NewToken() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// Gateway is the localhost forwarder. It verifies the agent's proxy token,
+// swaps in the real provider key, and streams the upstream response back.
+//
+// realKey lives here in memory for the gateway's lifetime — the proxy must
+// hold the key to use it. The win over `rapg run` is that the key is in THIS
+// process, not the agent's, so the agent never sees a reusable credential.
+type Gateway struct {
+	provider Provider
+	realKey  string
+	token    string
+	upstream *url.URL
+	client   *http.Client
+}
+
+// New builds a Gateway for the given provider, real key, and proxy token.
+func New(p Provider, realKey, token string) (*Gateway, error) {
+	base, err := url.Parse(p.UpstreamBaseURL())
+	if err != nil {
+		return nil, fmt.Errorf("proxy: bad upstream URL for %s: %w", p.Name(), err)
+	}
+	return &Gateway{
+		provider: p,
+		realKey:  realKey,
+		token:    token,
+		upstream: base,
+		client:   &http.Client{},
+	}, nil
+}
+
+// hopByHop headers must not be forwarded between connections (RFC 7230 6.1).
+var hopByHop = map[string]bool{
+	"Connection":          true,
+	"Proxy-Connection":    true,
+	"Keep-Alive":          true,
+	"Proxy-Authenticate":  true,
+	"Proxy-Authorization": true,
+	"Te":                  true,
+	"Trailer":             true,
+	"Transfer-Encoding":   true,
+	"Upgrade":             true,
+}
+
+func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// 1. Verify the proxy token in constant time. A mismatch (or an absent
+	//    token) is rejected before we touch the real key or the upstream.
+	got := g.provider.InboundToken(r)
+	if subtle.ConstantTimeCompare([]byte(got), []byte(g.token)) != 1 {
+		http.Error(w, "invalid or missing proxy token", http.StatusUnauthorized)
+		return
+	}
+
+	// 2. Build the outbound request against the upstream base.
+	out := *g.upstream
+	out.Path = singleJoiningSlash(g.upstream.Path, r.URL.Path)
+	out.RawQuery = r.URL.RawQuery
+
+	req, err := http.NewRequestWithContext(r.Context(), r.Method, out.String(), r.Body)
+	if err != nil {
+		http.Error(w, "proxy: could not build upstream request", http.StatusInternalServerError)
+		return
+	}
+	copyHeaders(req.Header, r.Header)
+	req.Host = g.upstream.Host
+	req.ContentLength = r.ContentLength
+
+	// 3. Swap the agent's proxy token for the real key.
+	g.provider.SetRealAuth(req, g.realKey)
+
+	// 4. Forward and stream the response back unchanged.
+	// #nosec G704 -- Not an open SSRF. The destination scheme+host are pinned
+	// to the provider's constant upstream (e.g. api.anthropic.com): `out` is a
+	// copy of g.upstream and only Path/RawQuery are taken from the agent's
+	// request. Forwarding the agent's path/query to a fixed host is exactly
+	// what a transparent API gateway does; the agent cannot redirect to an
+	// arbitrary host.
+	resp, err := g.client.Do(req)
+	if err != nil {
+		http.Error(w, "proxy: upstream request failed", http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+
+	copyHeaders(w.Header(), resp.Header)
+	w.WriteHeader(resp.StatusCode)
+	flushingCopy(w, resp.Body)
+}
+
+// copyHeaders copies non-hop-by-hop headers from src to dst.
+func copyHeaders(dst, src http.Header) {
+	for k, vv := range src {
+		if hopByHop[http.CanonicalHeaderKey(k)] {
+			continue
+		}
+		for _, v := range vv {
+			dst.Add(k, v)
+		}
+	}
+}
+
+// flushingCopy streams src to w, flushing after each chunk so server-sent
+// events (Anthropic/OpenAI token streaming) reach the agent immediately
+// rather than being buffered until the response ends.
+func flushingCopy(w http.ResponseWriter, src io.Reader) {
+	flusher, _ := w.(http.Flusher)
+	buf := make([]byte, 32*1024)
+	for {
+		n, rerr := src.Read(buf)
+		if n > 0 {
+			if _, werr := w.Write(buf[:n]); werr != nil {
+				return
+			}
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}
+		if rerr != nil {
+			return
+		}
+	}
+}
+
+// singleJoiningSlash joins two URL path segments with exactly one slash.
+func singleJoiningSlash(a, b string) string {
+	aslash := strings.HasSuffix(a, "/")
+	bslash := strings.HasPrefix(b, "/")
+	switch {
+	case aslash && bslash:
+		return a + b[1:]
+	case !aslash && !bslash:
+		return a + "/" + b
+	}
+	return a + b
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -24,7 +24,7 @@ func NewToken() (string, error) {
 // Gateway is the localhost forwarder. It verifies the agent's proxy token,
 // swaps in the real provider key, and streams the upstream response back.
 //
-// realKey lives here in memory for the gateway's lifetime — the proxy must
+// realKey lives here in memory for the gateway's lifetime; the proxy must
 // hold the key to use it. The win over `rapg run` is that the key is in THIS
 // process, not the agent's, so the agent never sees a reusable credential.
 type Gateway struct {
@@ -77,7 +77,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// 2. Build the outbound request against the upstream base. Preserve
-	//    RawPath so escaped path segments (e.g. %2F) survive — r.URL.Path is
+	//    RawPath so escaped path segments (e.g. %2F) survive: r.URL.Path is
 	//    unescaped, only RawPath carries the original encoding.
 	out := *g.upstream
 	out.Path = singleJoiningSlash(g.upstream.Path, r.URL.Path)

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -75,6 +75,33 @@ func TestGatewaySwapsTokenForRealKey(t *testing.T) {
 	}
 }
 
+func TestGatewayPreservesEscapedPath(t *testing.T) {
+	const token = "tok"
+	var sawRequestURI string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawRequestURI = r.RequestURI
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	g := newTestGateway(t, anthropic{}, "real", token, upstream.URL)
+	front := httptest.NewServer(g)
+	defer front.Close()
+
+	// %2F must reach the upstream still escaped, not decoded to a slash.
+	req, _ := http.NewRequest(http.MethodGet, front.URL+"/v1/models/a%2Fb", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if !strings.Contains(sawRequestURI, "%2F") {
+		t.Errorf("upstream RequestURI = %q, want it to keep the escaped %%2F", sawRequestURI)
+	}
+}
+
 func TestGatewayRejectsBadToken(t *testing.T) {
 	upstreamHit := false
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -189,6 +189,48 @@ func TestAnthropicChildEnv(t *testing.T) {
 	if env["ANTHROPIC_AUTH_TOKEN"] != "TOK" {
 		t.Errorf("ANTHROPIC_AUTH_TOKEN = %q", env["ANTHROPIC_AUTH_TOKEN"])
 	}
+	// Standard SDKs read ANTHROPIC_API_KEY (sent as x-api-key); it must be the
+	// token, not the real key.
+	if env["ANTHROPIC_API_KEY"] != "TOK" {
+		t.Errorf("ANTHROPIC_API_KEY = %q, want the proxy token", env["ANTHROPIC_API_KEY"])
+	}
+}
+
+func TestGatewayDoesNotFollowRedirects(t *testing.T) {
+	const token = "tok"
+	// Upstream redirects to an external host. If the gateway followed it, Go
+	// would resend x-api-key (the real key) to that host.
+	leak := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("x-api-key") != "" {
+			t.Errorf("real key leaked to redirect target: %q", r.Header.Get("x-api-key"))
+		}
+	}))
+	defer leak.Close()
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, leak.URL, http.StatusFound)
+	}))
+	defer upstream.Close()
+
+	g := newTestGateway(t, anthropic{}, "sk-ant-REAL", token, upstream.URL)
+	front := httptest.NewServer(g)
+	defer front.Close()
+
+	// Use a non-following client so we observe what the proxy returns rather
+	// than chasing the 302 ourselves.
+	client := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}}
+	req, _ := http.NewRequest(http.MethodGet, front.URL+"/v1/models", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+	// The 3xx is handed back to the agent rather than followed by the proxy.
+	if resp.StatusCode != http.StatusFound {
+		t.Errorf("status = %d, want 302 (redirect returned, not followed)", resp.StatusCode)
+	}
 }
 
 func TestLookup(t *testing.T) {

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1,0 +1,174 @@
+package proxy
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// newTestGateway builds a Gateway whose upstream points at a caller-supplied
+// test server instead of the real provider endpoint.
+func newTestGateway(t *testing.T, p Provider, realKey, token, upstreamURL string) *Gateway {
+	t.Helper()
+	g, err := New(p, realKey, token)
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	u, err := url.Parse(upstreamURL)
+	if err != nil {
+		t.Fatalf("parse upstream URL: %v", err)
+	}
+	g.upstream = u
+	return g
+}
+
+func TestGatewaySwapsTokenForRealKey(t *testing.T) {
+	const realKey = "sk-REAL-secret-key"
+	const token = "proxy-token-abc"
+
+	// Fake upstream asserts it sees the real key and never the proxy token.
+	var sawAuthHeader, sawKeyHeader, sawPath string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawAuthHeader = r.Header.Get("Authorization")
+		sawKeyHeader = r.Header.Get("x-api-key")
+		sawPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "upstream-ok")
+	}))
+	defer upstream.Close()
+
+	g := newTestGateway(t, anthropic{}, realKey, token, upstream.URL)
+	front := httptest.NewServer(g)
+	defer front.Close()
+
+	// Agent calls the gateway with the proxy token as a bearer (the
+	// ANTHROPIC_AUTH_TOKEN convention).
+	req, _ := http.NewRequest(http.MethodPost, front.URL+"/v1/messages", strings.NewReader("{}"))
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", resp.StatusCode, body)
+	}
+	if string(body) != "upstream-ok" {
+		t.Errorf("body = %q, want upstream-ok", body)
+	}
+	if sawKeyHeader != realKey {
+		t.Errorf("upstream x-api-key = %q, want real key %q", sawKeyHeader, realKey)
+	}
+	if sawAuthHeader != "" {
+		t.Errorf("upstream still saw Authorization = %q; proxy token must be stripped", sawAuthHeader)
+	}
+	if strings.Contains(sawAuthHeader, token) || sawKeyHeader == token {
+		t.Error("proxy token leaked to upstream")
+	}
+	if sawPath != "/v1/messages" {
+		t.Errorf("upstream path = %q, want /v1/messages", sawPath)
+	}
+}
+
+func TestGatewayRejectsBadToken(t *testing.T) {
+	upstreamHit := false
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHit = true
+	}))
+	defer upstream.Close()
+
+	g := newTestGateway(t, anthropic{}, "real", "good-token", upstream.URL)
+	front := httptest.NewServer(g)
+	defer front.Close()
+
+	cases := map[string]string{
+		"wrong token": "Bearer wrong-token",
+		"no auth":     "",
+	}
+	for name, auth := range cases {
+		t.Run(name, func(t *testing.T) {
+			req, _ := http.NewRequest(http.MethodGet, front.URL+"/v1/models", nil)
+			if auth != "" {
+				req.Header.Set("Authorization", auth)
+			}
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("request failed: %v", err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusUnauthorized {
+				t.Errorf("status = %d, want 401", resp.StatusCode)
+			}
+		})
+	}
+	if upstreamHit {
+		t.Error("upstream was reached despite an invalid proxy token")
+	}
+}
+
+func TestGatewayAcceptsXAPIKeyToken(t *testing.T) {
+	const token = "tok-via-xapikey"
+	var sawKey string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawKey = r.Header.Get("x-api-key")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	g := newTestGateway(t, anthropic{}, "REALKEY", token, upstream.URL)
+	front := httptest.NewServer(g)
+	defer front.Close()
+
+	// ANTHROPIC_API_KEY convention: the proxy token arrives as x-api-key.
+	req, _ := http.NewRequest(http.MethodGet, front.URL+"/v1/models", nil)
+	req.Header.Set("x-api-key", token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if sawKey != "REALKEY" {
+		t.Errorf("upstream x-api-key = %q, want REALKEY (real key must replace the token)", sawKey)
+	}
+}
+
+func TestNewToken(t *testing.T) {
+	a, err := NewToken()
+	if err != nil {
+		t.Fatalf("NewToken failed: %v", err)
+	}
+	if len(a) != 64 { // 32 bytes hex-encoded
+		t.Errorf("token length = %d, want 64 hex chars", len(a))
+	}
+	b, _ := NewToken()
+	if a == b {
+		t.Error("two NewToken calls returned the same token")
+	}
+}
+
+func TestAnthropicChildEnv(t *testing.T) {
+	env := anthropic{}.ChildEnv("http://127.0.0.1:7777", "TOK")
+	if env["ANTHROPIC_BASE_URL"] != "http://127.0.0.1:7777" {
+		t.Errorf("ANTHROPIC_BASE_URL = %q", env["ANTHROPIC_BASE_URL"])
+	}
+	if env["ANTHROPIC_AUTH_TOKEN"] != "TOK" {
+		t.Errorf("ANTHROPIC_AUTH_TOKEN = %q", env["ANTHROPIC_AUTH_TOKEN"])
+	}
+}
+
+func TestLookup(t *testing.T) {
+	if _, err := Lookup("anthropic"); err != nil {
+		t.Errorf("Lookup(anthropic) error: %v", err)
+	}
+	if _, err := Lookup("nope"); err == nil {
+		t.Error("Lookup(nope) should return an error")
+	}
+}


### PR DESCRIPTION
Implements **step 2 of `docs/proxy-design.md`** (see #19): the `internal/proxy` package. No CLI wiring or vault integration yet — that's the next PR. Pure, network-free, vault-free, fully unit-tested.

## What's here

- **`Provider` interface + `anthropic` provider.** Upstream `api.anthropic.com`; real key sent as `x-api-key`; accepts the agent's proxy token via either `Authorization: Bearer` (the `ANTHROPIC_AUTH_TOKEN` convention) or `x-api-key` (the `ANTHROPIC_API_KEY` convention); child env = `ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN`.
- **`Gateway` forwarder.** Constant-time proxy-token check → swaps in the real key → forwards. Destination host is **pinned to the provider constant** (only path/query come from the agent), hop-by-hop headers stripped, response streamed with a per-chunk flush so SSE token streaming isn't buffered.
- **`NewToken`.** 32-byte `crypto/rand`, hex, minted per invocation, memory-only.

## Tests (httptest fake upstream, no network)

- proxy token is swapped for the real key, and **never leaks upstream**
- bad / missing token → 401 **without reaching upstream**
- `x-api-key` token path
- token uniqueness, child env mapping, provider lookup

## Security note

`#nosec G704` is documented on the forward call: the scheme+host are pinned to the upstream constant, so it is not an open SSRF — forwarding the agent's path/query to a fixed host is the gateway's whole job.

## Verification (run locally, real output)

`go build`, `go test ./...`, `go vet`, `staticcheck`, `gosec` (0 issues), `gofmt -l` — all clean.

## Next

CLI wiring (`rapg proxy --provider anthropic -- <cmd>`: vault unlock, key lookup by env-key, child launch + teardown, session-log entry) is the follow-up PR.
