### PR TITLE
feat(proxy): add openai provider

### DIFF
--- a/cmd/rapg/main.go
+++ b/cmd/rapg/main.go
@@ -327,7 +327,7 @@ Example:
 			runProxy(proxyProvider, proxyEnvKey, proxyPort, args)
 		},
 	}
-	proxyCmd.Flags().StringVar(&proxyProvider, "provider", "", "API provider to proxy (anthropic)")
+	proxyCmd.Flags().StringVar(&proxyProvider, "provider", "", "API provider to proxy (anthropic, openai)")
 	proxyCmd.Flags().StringVar(&proxyEnvKey, "env-key", "", "vault Env Key holding the real API key (default: the provider's standard key)")
 	proxyCmd.Flags().IntVar(&proxyPort, "port", 0, "localhost port to listen on (0 = ephemeral)")
 	_ = proxyCmd.MarkFlagRequired("provider")

--- a/internal/proxy/provider.go
+++ b/internal/proxy/provider.go
@@ -44,8 +44,10 @@ func Lookup(name string) (Provider, error) {
 	switch name {
 	case "anthropic":
 		return anthropic{}, nil
+	case "openai":
+		return openai{}, nil
 	default:
-		return nil, fmt.Errorf("unsupported provider %q (supported: anthropic)", name)
+		return nil, fmt.Errorf("unsupported provider %q (supported: anthropic, openai)", name)
 	}
 }
 
@@ -88,5 +90,31 @@ func (anthropic) ChildEnv(listenURL, proxyToken string) map[string]string {
 	return map[string]string{
 		"ANTHROPIC_BASE_URL":   listenURL,
 		"ANTHROPIC_AUTH_TOKEN": proxyToken,
+	}
+}
+
+// openai targets api.openai.com. The OpenAI SDKs send the key as
+// "Authorization: Bearer <key>" and read OPENAI_BASE_URL + OPENAI_API_KEY.
+// OPENAI_BASE_URL must include the /v1 path segment because the SDK appends
+// endpoint paths (e.g. /chat/completions) directly to it.
+type openai struct{}
+
+func (openai) Name() string            { return "openai" }
+func (openai) DefaultEnvKey() string   { return "OPENAI_API_KEY" }
+func (openai) UpstreamBaseURL() string { return "https://api.openai.com" }
+
+func (openai) InboundToken(r *http.Request) string {
+	return bearer(r)
+}
+
+func (openai) SetRealAuth(r *http.Request, realKey string) {
+	r.Header.Del("x-api-key")
+	r.Header.Set("Authorization", "Bearer "+realKey)
+}
+
+func (openai) ChildEnv(listenURL, proxyToken string) map[string]string {
+	return map[string]string{
+		"OPENAI_BASE_URL": listenURL + "/v1",
+		"OPENAI_API_KEY":  proxyToken,
 	}
 }

--- a/internal/proxy/provider.go
+++ b/internal/proxy/provider.go
@@ -113,8 +113,12 @@ func (openai) SetRealAuth(r *http.Request, realKey string) {
 }
 
 func (openai) ChildEnv(listenURL, proxyToken string) map[string]string {
+	base := listenURL + "/v1"
 	return map[string]string{
-		"OPENAI_BASE_URL": listenURL + "/v1",
+		"OPENAI_BASE_URL": base,
+		// OPENAI_API_BASE is the legacy variable older SDKs (pre-v1 Python) and
+		// some third-party tools still read. Set both for broad compatibility.
+		"OPENAI_API_BASE": base,
 		"OPENAI_API_KEY":  proxyToken,
 	}
 }

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -204,7 +204,7 @@ func TestOpenAISwapsTokenForRealKey(t *testing.T) {
 
 func TestOpenAIChildEnv(t *testing.T) {
 	env := openai{}.ChildEnv("http://127.0.0.1:7777", "TOK")
-	// Base URL must carry /v1 — the SDK appends endpoint paths to it.
+	// Base URL must carry /v1, since the SDK appends endpoint paths to it.
 	if env["OPENAI_BASE_URL"] != "http://127.0.0.1:7777/v1" {
 		t.Errorf("OPENAI_BASE_URL = %q, want .../v1", env["OPENAI_BASE_URL"])
 	}

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -167,6 +167,52 @@ func TestGatewayAcceptsXAPIKeyToken(t *testing.T) {
 	}
 }
 
+func TestOpenAISwapsTokenForRealKey(t *testing.T) {
+	const realKey = "sk-openai-REAL"
+	const token = "openai-proxy-token"
+
+	var sawAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	g := newTestGateway(t, openai{}, realKey, token, upstream.URL)
+	front := httptest.NewServer(g)
+	defer front.Close()
+
+	// OpenAI SDK convention: token arrives as Authorization: Bearer.
+	req, _ := http.NewRequest(http.MethodPost, front.URL+"/v1/chat/completions", strings.NewReader("{}"))
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if sawAuth != "Bearer "+realKey {
+		t.Errorf("upstream Authorization = %q, want bearer real key", sawAuth)
+	}
+	if strings.Contains(sawAuth, token) {
+		t.Error("proxy token leaked to upstream")
+	}
+}
+
+func TestOpenAIChildEnv(t *testing.T) {
+	env := openai{}.ChildEnv("http://127.0.0.1:7777", "TOK")
+	// Base URL must carry /v1 — the SDK appends endpoint paths to it.
+	if env["OPENAI_BASE_URL"] != "http://127.0.0.1:7777/v1" {
+		t.Errorf("OPENAI_BASE_URL = %q, want .../v1", env["OPENAI_BASE_URL"])
+	}
+	if env["OPENAI_API_KEY"] != "TOK" {
+		t.Errorf("OPENAI_API_KEY = %q", env["OPENAI_API_KEY"])
+	}
+}
+
 func TestNewToken(t *testing.T) {
 	a, err := NewToken()
 	if err != nil {

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -208,6 +208,10 @@ func TestOpenAIChildEnv(t *testing.T) {
 	if env["OPENAI_BASE_URL"] != "http://127.0.0.1:7777/v1" {
 		t.Errorf("OPENAI_BASE_URL = %q, want .../v1", env["OPENAI_BASE_URL"])
 	}
+	// Legacy var must be set too for older SDKs.
+	if env["OPENAI_API_BASE"] != "http://127.0.0.1:7777/v1" {
+		t.Errorf("OPENAI_API_BASE = %q, want .../v1", env["OPENAI_API_BASE"])
+	}
 	if env["OPENAI_API_KEY"] != "TOK" {
 		t.Errorf("OPENAI_API_KEY = %q", env["OPENAI_API_KEY"])
 	}


### PR DESCRIPTION
Adds the `openai` provider. Implements step 4 of `docs/proxy-design.md`. **Stacked on #22** (base = `feat/proxy-cli`).

## What's here

- `openai` provider: upstream `api.openai.com`; real key sent as `Authorization: Bearer`; proxy token read from the same header; child env `OPENAI_BASE_URL` (with the `/v1` suffix the SDK appends endpoint paths to) + `OPENAI_API_KEY`.
- Registered in `Lookup`; `--provider` help text updated to `anthropic, openai`.
- Tests: token→real-key swap via bearer (token never leaks upstream), child env carries `/v1`.

The core forwarder needed **no changes** — adding a second provider is the proof that the `Provider` abstraction holds.

## Verification (real output)

`go build`, `go test ./...`, `go vet`, `staticcheck`, `gosec` (0 issues), `gofmt -l` — all clean.
