### PR TITLE
ci: add goreleaser-cross release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Release
+
+# Build and publish cross-platform binaries on tag push.
+#
+# rapg links go-sqlite3, so CGO is required and plain cross-compilation from a
+# single host fails (the host C toolchain can't target other OSes). We run
+# GoReleaser inside the goreleaser-cross image, which bundles the C
+# cross-toolchains (incl. osxcross) for linux / windows / darwin.
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Full history + tags so GoReleaser can build the changelog and
+          # validate the tag.
+          fetch-depth: 0
+
+      - name: Run GoReleaser (cross, CGO)
+        # GITHUB_TOKEN publishes the release on this repo. TAP_GITHUB_TOKEN is a
+        # PAT with write access to kanywst/homebrew-tap (a cross-repo push the
+        # default GITHUB_TOKEN can't do); set it as a repo secret. The
+        # safe.directory line avoids git's "dubious ownership" error when the
+        # container root user reads the runner-owned checkout.
+        run: |
+          docker run --rm \
+            -e GITHUB_TOKEN="${{ secrets.GITHUB_TOKEN }}" \
+            -e TAP_GITHUB_TOKEN="${{ secrets.TAP_GITHUB_TOKEN }}" \
+            -v "$PWD":/go/src/github.com/kanywst/rapg \
+            -w /go/src/github.com/kanywst/rapg \
+            --entrypoint /bin/bash \
+            goreleaser/goreleaser-cross:v1.26.3 \
+            -c "git config --global --add safe.directory /go/src/github.com/kanywst/rapg && goreleaser release --clean"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -21,7 +21,7 @@ builds:
       - -s -w
 
 archives:
-  - format: tar.gz
+  - formats: [tar.gz]
     # this name template makes the OS and Arch compatible with the results of uname.
     name_template: >-
       {{ .ProjectName }}_
@@ -33,13 +33,13 @@ archives:
     # use zip for windows archives
     format_overrides:
     - goos: windows
-      format: zip
+      formats: [zip]
 
 checksum:
   name_template: 'checksums.txt'
 
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 
 changelog:
   sort: asc


### PR DESCRIPTION
Adds a tag-triggered Release pipeline so `v*` tags publish cross-platform binaries.

## Why a Docker-based pipeline

rapg links `go-sqlite3`, so **CGO is required**. Plain cross-compilation from one host fails (the host C toolchain can't target other OSes — verified: a local `goreleaser release --snapshot` dies on `setresgid`/`clearenv` when building linux from macOS). The workflow runs GoReleaser inside `goreleaser/goreleaser-cross:v1.26.3`, which bundles the C cross-toolchains (incl. osxcross) for linux / windows / darwin.

## What it does on `git push` of a `v*` tag

- Cross-compiles `linux/windows/darwin × amd64/arm64` with CGO.
- Publishes the GitHub Release with binaries + `checksums.txt` and an auto changelog.
- Pushes the Homebrew formula to `kanywst/homebrew-tap`.

## Required secret

- `TAP_GITHUB_TOKEN` — a PAT with write access to `kanywst/homebrew-tap` (the default `GITHUB_TOKEN` can't push cross-repo). Set it under repo Settings → Secrets. If it's absent, the Homebrew step is the only thing that fails; the binaries still publish.

## Also

- Modernized `.goreleaser.yaml`: `archives.format` → `formats`, `snapshot.name_template` → `version_template`. (`brews` is still deprecated-but-functional; migrating to `homebrew_casks` is a separate cleanup.)

## After merge

Tag `v0.3.0` on master and push it to trigger the release.
