### PR TITLE
fix(ci): set per-target CC/CXX for CGO cross-compilation

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,9 +16,42 @@ builds:
     goarch:
       - amd64
       - arm64
+    ignore:
+      # mingw arm64 CGO support is fragile; skip this niche target.
+      - goos: windows
+        goarch: arm64
     main: ./cmd/rapg
     ldflags:
       - -s -w
+    # CGO needs a per-target C cross-compiler. These names are the ones the
+    # goreleaser-cross image provides; without them CGO falls back to the host
+    # gcc and fails to assemble other architectures.
+    overrides:
+      - goos: linux
+        goarch: amd64
+        env:
+          - CC=x86_64-linux-gnu-gcc
+          - CXX=x86_64-linux-gnu-g++
+      - goos: linux
+        goarch: arm64
+        env:
+          - CC=aarch64-linux-gnu-gcc
+          - CXX=aarch64-linux-gnu-g++
+      - goos: windows
+        goarch: amd64
+        env:
+          - CC=x86_64-w64-mingw32-gcc
+          - CXX=x86_64-w64-mingw32-g++
+      - goos: darwin
+        goarch: amd64
+        env:
+          - CC=o64-clang
+          - CXX=o64-clang++
+      - goos: darwin
+        goarch: arm64
+        env:
+          - CC=oa64-clang
+          - CXX=oa64-clang++
 
 archives:
   - formats: [tar.gz]


### PR DESCRIPTION
The v0.3.0 release workflow failed building linux/arm64: CGO used the host gcc, so arm64 assembly hit the x86 assembler (`no such instruction: stp/ldp/blr`).

Wire each GOOS/GOARCH to the goreleaser-cross cross-compiler via build `overrides` (`x86_64/aarch64-linux-gnu-gcc`, `x86_64-w64-mingw32-gcc`, `o64/oa64-clang`). Skip `windows/arm64` (mingw arm64 CGO is fragile).

`goreleaser check` passes (only the pre-existing `brews` deprecation warning). After merge, re-tag v0.3.0 to re-trigger the release.